### PR TITLE
no longer shuffles on delete, does not break pagination

### DIFF
--- a/src/hexagon/application/queries/useFlashcardsQuery.ts
+++ b/src/hexagon/application/queries/useFlashcardsQuery.ts
@@ -92,6 +92,16 @@ export const useFlashcardsQuery = (): UseFlashcardsQueryReturnType => {
     queryKey: ['flashcards', userId],
     queryFn: () => getFlashcards(),
     enabled: hasAccess && appUser !== null && userId !== undefined,
+    select: (data) =>
+      [...data].sort((a, b) => {
+        const timeA = a.dateCreated
+          ? new Date(a.dateCreated).getTime()
+          : 0;
+        const timeB = b.dateCreated
+          ? new Date(b.dateCreated).getTime()
+          : 0;
+        return timeB - timeA;
+      }),
     ...queryDefaults.entityData,
   });
 

--- a/src/hexagon/application/queries/useFlashcardsQuery.ts
+++ b/src/hexagon/application/queries/useFlashcardsQuery.ts
@@ -92,16 +92,16 @@ export const useFlashcardsQuery = (): UseFlashcardsQueryReturnType => {
     queryKey: ['flashcards', userId],
     queryFn: () => getFlashcards(),
     enabled: hasAccess && appUser !== null && userId !== undefined,
-    select: (data) =>
-      [...data].sort((a, b) => {
-        const timeA = a.dateCreated
-          ? new Date(a.dateCreated).getTime()
-          : 0;
-        const timeB = b.dateCreated
-          ? new Date(b.dateCreated).getTime()
-          : 0;
-        return timeB - timeA;
-      }),
+    select: (data) => {
+      const safeTime = (dateStr: string | null | undefined): number => {
+        if (!dateStr) return 0;
+        const t = new Date(dateStr).getTime();
+        return Number.isFinite(t) ? t : 0;
+      };
+      return [...data].sort(
+        (a, b) => safeTime(b.dateCreated) - safeTime(a.dateCreated),
+      );
+    },
     ...queryDefaults.entityData,
   });
 

--- a/src/hexagon/application/units/Pagination/usePagination.test.ts
+++ b/src/hexagon/application/units/Pagination/usePagination.test.ts
@@ -18,4 +18,18 @@ describe('usePagination', () => {
     expect(result.current.nextPage).toBeDefined();
     expect(result.current.previousPage).toBeDefined();
   });
+
+  it('when totalItems is 0, pageNumber is 1 and indices are non-negative', () => {
+    const { result } = renderHook(() =>
+      usePagination({
+        itemsPerPage: 5,
+        totalItems: 0,
+      }),
+    );
+
+    expect(result.current.pageNumber).toBe(1);
+    expect(result.current.maxPageNumber).toBe(0);
+    expect(result.current.startIndex).toBe(0);
+    expect(result.current.endIndex).toBe(0);
+  });
 });

--- a/src/hexagon/application/units/Pagination/usePagination.ts
+++ b/src/hexagon/application/units/Pagination/usePagination.ts
@@ -27,6 +27,9 @@ export function usePagination({
   const maxPage = Math.ceil(totalItems / itemsPerPage);
 
   const safePageNumber = useMemo(() => {
+    if (maxPage === 0) {
+      return 1;
+    }
     if (selectedPageNumber > maxPage) {
       return maxPage;
     }
@@ -41,8 +44,8 @@ export function usePagination({
   }, [safePageNumber, itemsPerPage]);
 
   const endIndex = useMemo(() => {
-    return startIndex + itemsPerPage;
-  }, [startIndex, itemsPerPage]);
+    return Math.min(startIndex + itemsPerPage, totalItems);
+  }, [startIndex, itemsPerPage, totalItems]);
 
   const nextPage = useCallback(() => {
     if (safePageNumber >= maxPage) {

--- a/src/hexagon/application/units/Pagination/usePagination.ts
+++ b/src/hexagon/application/units/Pagination/usePagination.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 export interface PaginationState {
   totalItems: number;
@@ -24,14 +24,9 @@ export function usePagination({
   totalItems,
 }: UsePaginationParams): PaginationState {
   const [selectedPageNumber, setSelectedPageNumber] = useState(1);
-  const previousTotalItems = useRef(0);
   const maxPage = Math.ceil(totalItems / itemsPerPage);
 
   const safePageNumber = useMemo(() => {
-    if (previousTotalItems.current !== totalItems) {
-      previousTotalItems.current = totalItems;
-      return 1;
-    }
     if (selectedPageNumber > maxPage) {
       return maxPage;
     }
@@ -39,7 +34,7 @@ export function usePagination({
       return 1;
     }
     return selectedPageNumber;
-  }, [selectedPageNumber, maxPage, totalItems]);
+  }, [selectedPageNumber, maxPage]);
 
   const startIndex = useMemo(() => {
     return (safePageNumber - 1) * itemsPerPage;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized client-side ordering and pagination bounds fixes with added test coverage; low risk aside from potential UI ordering change due to the new explicit sort.
> 
> **Overview**
> Flashcard query results are now **deterministically ordered** by sorting `useFlashcardsQuery` data by `dateCreated` (descending) in the React Query `select`, avoiding reshuffles after cache updates like deletes.
> 
> `usePagination` now handles `totalItems=0` safely by clamping `endIndex` to `totalItems` and ensuring the page number stays at `1`; a new unit test covers the empty-list case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b675f52b259856c73f8968820a4ec649e9ee7cd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->