### PR TITLE
Improvement/audio quiz 2 second buffer

### DIFF
--- a/src/hexagon/application/units/AudioQuiz/useAudioQuiz.mock.ts
+++ b/src/hexagon/application/units/AudioQuiz/useAudioQuiz.mock.ts
@@ -127,6 +127,8 @@ export function createMockAudioQuizReturn(
     previousExampleReady: false,
     progressStatus: 0,
     isPlaying: false,
+    isBufferVisible: false,
+    bufferProgress: 0,
     pause: vi.fn<() => void>(),
     play: vi.fn<() => void>(),
     nextStep: vi.fn<() => void>(),

--- a/src/hexagon/application/units/AudioQuiz/useAudioQuiz.test.ts
+++ b/src/hexagon/application/units/AudioQuiz/useAudioQuiz.test.ts
@@ -75,6 +75,8 @@ describe('useAudioQuiz', () => {
       expect(result.current.isQuizComplete).toBe(false);
       expect(result.current.autoplay).toBe(false);
       expect(result.current.audioQuizType).toBe(AudioQuizType.Speaking);
+      expect(result.current.isBufferVisible).toBe(false);
+      expect(result.current.bufferProgress).toBe(0);
     });
 
     // Note: Empty examples array test removed - exposes a bug in useAudioQuiz.ts
@@ -360,6 +362,114 @@ describe('useAudioQuiz', () => {
       expect(result.current.isQuizComplete).toBe(false);
       expect(result.current.getHelpIsOpen).toBe(false);
       expect(mockAudioAdapter.cleanupAudio).toHaveBeenCalled();
+    });
+  });
+
+  describe('autoplay 2-second buffer', () => {
+    function getOnEndedFromAdapter(): () => void {
+      const calls = (
+        mockAudioAdapter.changeCurrentAudio as ReturnType<typeof vi.fn>
+      ).mock.calls;
+      const last = calls[calls.length - 1];
+      if (!last?.[0]?.onEnded) {
+        throw new Error('changeCurrentAudio was not called with onEnded');
+      }
+      return last[0].onEnded;
+    }
+
+    it('when audio ends on Question step, starts 2s buffer then advances to Guess', async () => {
+      const { result } = renderHook(() =>
+        useAudioQuiz({ ...defaultProps, autoplay: true }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.currentExampleReady).toBe(true);
+      });
+      expect(result.current.currentStep).toBe(AudioQuizStep.Question);
+
+      const onEnded = getOnEndedFromAdapter();
+      vi.useFakeTimers();
+
+      try {
+        act(() => {
+          onEnded();
+        });
+        expect(result.current.isBufferVisible).toBe(true);
+
+        act(() => {
+          vi.advanceTimersByTime(2000);
+        });
+        expect(result.current.currentStep).toBe(AudioQuizStep.Guess);
+        expect(result.current.isBufferVisible).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('when audio ends on Guess step, advances immediately (no buffer)', async () => {
+      const { result } = renderHook(() =>
+        useAudioQuiz({ ...defaultProps, autoplay: true }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.currentExampleReady).toBe(true);
+      });
+
+      act(() => {
+        result.current.nextStep(); // Question → Guess
+      });
+      expect(result.current.currentStep).toBe(AudioQuizStep.Guess);
+
+      const onEnded = getOnEndedFromAdapter();
+      act(() => {
+        onEnded();
+      });
+
+      expect(result.current.currentStep).toBe(AudioQuizStep.Hint);
+      expect(result.current.isBufferVisible).toBe(false);
+    });
+
+    it('direct step navigation clears buffer', async () => {
+      const { result } = renderHook(() =>
+        useAudioQuiz({ ...defaultProps, autoplay: true }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.currentExampleReady).toBe(true);
+      });
+
+      const onEnded = getOnEndedFromAdapter();
+      act(() => {
+        onEnded();
+      });
+      expect(result.current.isBufferVisible).toBe(true);
+
+      act(() => {
+        result.current.goToQuestion();
+      });
+      expect(result.current.isBufferVisible).toBe(false);
+    });
+
+    it('pause does nothing while buffer is active', async () => {
+      const { result } = renderHook(() =>
+        useAudioQuiz({ ...defaultProps, autoplay: true }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.currentExampleReady).toBe(true);
+      });
+
+      const onEnded = getOnEndedFromAdapter();
+      act(() => {
+        onEnded();
+      });
+      expect(result.current.isBufferVisible).toBe(true);
+
+      (mockAudioAdapter.pause as ReturnType<typeof vi.fn>).mockClear();
+      act(() => {
+        result.current.pause();
+      });
+      expect(mockAudioAdapter.pause).not.toHaveBeenCalled();
     });
   });
 

--- a/src/hexagon/application/units/AudioQuiz/useAudioQuiz.ts
+++ b/src/hexagon/application/units/AudioQuiz/useAudioQuiz.ts
@@ -44,6 +44,10 @@ export interface AudioQuizReturn {
   previousExampleReady: boolean;
   progressStatus: number;
   isPlaying: boolean;
+  /** True when the 2s buffer is active and we're on a step that shows it (Question, Hint, Answer only – not Guess) */
+  isBufferVisible: boolean;
+  /** 0–1 progress of the 2-second buffer (for UI) */
+  bufferProgress: number;
   pause: () => void;
   play: () => void;
   nextStep: () => void;
@@ -119,8 +123,8 @@ export function useAudioQuiz({
   cleanupFunction, // Function to clean up the quiz
 }: AudioQuizProps): AudioQuizReturn {
   const {
-    play,
-    pause,
+    play: playAudio,
+    pause: pauseAudio,
     isPlaying,
     currentTime,
     changeCurrentAudio,
@@ -190,7 +194,27 @@ export function useAudioQuiz({
   // State to trigger audio restart without changing step or example
   const [restartTrigger, setRestartTrigger] = useState<number>(0);
 
-  // The current example number (1-indexed for UI purposes)
+  // 2-second buffer between steps in autoplay (gives users time to guess)
+  const BUFFER_MS = 2000;
+  const BUFFER_TICK_MS = 25;
+  const [isBufferActive, setIsBufferActive] = useState<boolean>(false);
+  const [bufferProgress, setBufferProgress] = useState<number>(0);
+  const bufferTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const bufferIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearBufferTimers = useCallback(() => {
+    if (bufferTimeoutRef.current) {
+      clearTimeout(bufferTimeoutRef.current);
+      bufferTimeoutRef.current = null;
+    }
+    if (bufferIntervalRef.current) {
+      clearInterval(bufferIntervalRef.current);
+      bufferIntervalRef.current = null;
+    }
+    setIsBufferActive(false);
+    setBufferProgress(0);
+  }, []);
+
   // Used only in export for UI, should not be referenced for stateful logic
   const currentExampleNumber = currentExampleIndex + 1; // 1-indexed
 
@@ -363,6 +387,7 @@ export function useAudioQuiz({
 
   // Simple utility functions to increment and decrement the example index
   const nextExample = useCallback(() => {
+    clearBufferTimers();
     if (nextExampleReady) {
       setSelectedExampleIndex(currentExampleIndex + 1);
       setCurrentStep(AudioQuizStep.Question);
@@ -381,9 +406,11 @@ export function useAudioQuiz({
     safeExamples.length,
     setSelectedExampleIndex,
     nextExampleReady,
+    clearBufferTimers,
   ]);
 
   const previousExample = useCallback(() => {
+    clearBufferTimers();
     if (previousExampleReady) {
       // Go to the previous example if it is ready
       setSelectedExampleIndex(currentExampleIndex - 1);
@@ -392,10 +419,16 @@ export function useAudioQuiz({
       // Reset the previous step ref to null so progress animation works immediately on new example
       previousStepRef.current = null;
     }
-  }, [currentExampleIndex, setSelectedExampleIndex, previousExampleReady]);
+  }, [
+    currentExampleIndex,
+    setSelectedExampleIndex,
+    previousExampleReady,
+    clearBufferTimers,
+  ]);
 
   // Resets the quiz to the initial state, called on menu and end of autoplay
   const restartQuiz = useCallback(() => {
+    clearBufferTimers();
     setSelectedExampleIndex(0);
     setCurrentStep(AudioQuizStep.Question);
     previousStepRef.current = null;
@@ -409,10 +442,11 @@ export function useAudioQuiz({
     if (getHelpIsOpen) {
       setGetHelpIsOpen(false);
     }
-  }, [cleanupAudio, getHelpIsOpen]);
+  }, [cleanupAudio, getHelpIsOpen, clearBufferTimers]);
 
   // Steps the quiz forward
   const nextStep = useCallback(() => {
+    clearBufferTimers();
     switch (currentStep) {
       case AudioQuizStep.Question:
         if (autoplay) {
@@ -435,7 +469,7 @@ export function useAudioQuiz({
       default:
         console.error('Invalid currentStep value: ', currentStep);
     }
-  }, [autoplay, currentStep, nextExample]);
+  }, [autoplay, currentStep, nextExample, clearBufferTimers]);
 
   // Get the values related to the current step
   const currentStepValue = useMemo(() => {
@@ -507,41 +541,86 @@ export function useAudioQuiz({
     currentExampleIndex,
   ]);
 
-  // What to do when the audio ends - simplified since concatenated audio handles padding
+  // What to do when the audio ends - 2s buffer only after Question, Hint, Answer (not after Guess)
   const onEndedCallback = useCallback(() => {
     if (!autoplay) {
       return;
     }
 
-    // No need for complex padding logic - concatenated audio handles it seamlessly
-    nextStep();
-  }, [autoplay, nextStep]);
+    if (currentStep === AudioQuizStep.Guess) {
+      nextStep();
+      return;
+    }
+
+    // Start 2-second buffer before advancing from Question, Hint, or Answer
+    clearBufferTimers();
+    setIsBufferActive(true);
+    setBufferProgress(0);
+
+    let elapsed = 0;
+    bufferIntervalRef.current = setInterval(() => {
+      elapsed += BUFFER_TICK_MS;
+      const progress = Math.min(elapsed / BUFFER_MS, 1);
+      setBufferProgress(progress);
+    }, BUFFER_TICK_MS);
+
+    bufferTimeoutRef.current = setTimeout(() => {
+      clearBufferTimers();
+      nextStep();
+    }, BUFFER_MS);
+  }, [autoplay, currentStep, nextStep, clearBufferTimers]);
+
+  // Single display flag: buffer is shown only on Question, Hint, Answer (not Guess)
+  const isBufferVisible = useMemo(
+    () =>
+      isBufferActive &&
+      (currentStep === AudioQuizStep.Question ||
+        currentStep === AudioQuizStep.Hint ||
+        currentStep === AudioQuizStep.Answer),
+    [isBufferActive, currentStep],
+  );
 
   const goToQuestion = useCallback(() => {
+    clearBufferTimers();
     setCurrentStep(AudioQuizStep.Question);
     // Let the main useEffect handle audio changes for consistency
-  }, []);
+  }, [clearBufferTimers]);
 
   const goToGuess = useCallback(() => {
+    clearBufferTimers();
     setCurrentStep(AudioQuizStep.Guess);
     // Let the main useEffect handle audio changes for consistency
-  }, []);
+  }, [clearBufferTimers]);
 
   const goToHint = useCallback(() => {
+    clearBufferTimers();
     setCurrentStep(AudioQuizStep.Hint);
     // Let the main useEffect handle audio changes for consistency
-  }, []);
+  }, [clearBufferTimers]);
 
   const goToAnswer = useCallback(() => {
+    clearBufferTimers();
     setCurrentStep(AudioQuizStep.Answer);
     // Let the main useEffect handle audio changes for consistency
-  }, []);
+  }, [clearBufferTimers]);
 
   const restartCurrentStep = useCallback(() => {
+    clearBufferTimers();
     // Trigger a restart by incrementing the restart trigger
     // This will cause the audio effect to restart without changing step or example
     setRestartTrigger((prev) => prev + 1);
-  }, []);
+  }, [clearBufferTimers]);
+
+  const pause = useCallback(() => {
+    if (isBufferActive) return;
+    clearBufferTimers();
+    pauseAudio();
+  }, [isBufferActive, clearBufferTimers, pauseAudio]);
+
+  const play = useCallback(() => {
+    if (isBufferActive) return;
+    playAudio();
+  }, [isBufferActive, playAudio]);
 
   // Effect to parse the audio examples when the current example is ready
   useEffect(() => {
@@ -600,6 +679,7 @@ export function useAudioQuiz({
 
     // check if quiz ended, end current audio
     if (isQuizComplete) {
+      clearBufferTimers();
       cleanupAudio();
       return;
     }
@@ -647,6 +727,7 @@ export function useAudioQuiz({
     currentStepValue,
     restartTrigger,
     isQuizComplete,
+    clearBufferTimers,
     cleanupAudio,
     changeCurrentAudio,
     onEndedCallback,
@@ -655,9 +736,10 @@ export function useAudioQuiz({
   // Cleanup audio when the quiz component unmounts or cleanupFunction is called
   useEffect(() => {
     return () => {
+      clearBufferTimers();
       cleanupAudio();
     };
-  }, [cleanupAudio]);
+  }, [cleanupAudio, clearBufferTimers]);
 
   // for getHelp
   const vocabComplete = useMemo(() => {
@@ -739,6 +821,8 @@ export function useAudioQuiz({
     nextExampleReady, // Whether the next example is ready to be played
     previousExampleReady, // Whether the previous example is ready to be played
     isPlaying,
+    isBufferVisible,
+    bufferProgress,
     pause, // Pauses the current audio
     play,
     nextStep,

--- a/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioBasedReview.css
+++ b/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioBasedReview.css
@@ -78,6 +78,29 @@ button:disabled {
 
 .progressStatus {
   z-index: 1;
+  border-top-right-radius: 10px;
+  border-bottom-right-radius: 10px;
+}
+
+.audioQuizBuffer {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.audioQuizBufferCircle {
+  width: 44px;
+  height: 44px;
+  transform: rotate(-90deg); /* start countdown from top */
+}
+
+.audioQuizBufferCircleStroke {
+  stroke: var(--brand);
+  stroke-width: 3;
 }
 
 .getHelpContainer {

--- a/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.test.tsx
+++ b/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.test.tsx
@@ -28,6 +28,8 @@ function AudioFlashcardAutoplayOn() {
         nextStep={incrementCurrentStep}
         autoplay
         progressStatus={0.5}
+        isBufferVisible={false}
+        bufferProgress={0}
         pause={pausePlayback}
         play={resumePlayback}
         isPlaying
@@ -56,6 +58,8 @@ function AudioFlashcardAutoplayOff() {
         nextStep={incrementCurrentStep}
         autoplay={false}
         progressStatus={0.5}
+        isBufferVisible={false}
+        bufferProgress={0}
         pause={pausePlayback}
         play={resumePlayback}
         isPlaying
@@ -85,6 +89,8 @@ function AudioFlashcardPlaying() {
         nextStep={incrementCurrentStep}
         autoplay
         progressStatus={0.5}
+        isBufferVisible={false}
+        bufferProgress={0}
         pause={pausePlayback}
         play={resumePlayback}
         isPlaying
@@ -113,6 +119,8 @@ function AudioFlashcardPaused() {
         nextStep={incrementCurrentStep}
         autoplay
         progressStatus={0.5}
+        isBufferVisible={false}
+        bufferProgress={0}
         pause={pausePlayback}
         play={resumePlayback}
         isPlaying={false}
@@ -173,6 +181,33 @@ describe('component AudioFlashcard', () => {
         screen.getAllByLabelText('Play/Pause')[0].click();
         expect(resumePlayback).toHaveBeenCalledOnce();
       });
+    });
+  });
+
+  describe('buffer UI', () => {
+    it('when autoplay and isBufferVisible are true, renders buffer element', () => {
+      render(
+        <MockAllProviders>
+          <AudioFlashcardComponent
+            currentExampleText="currentExampleText"
+            currentStep={AudioQuizStep.Question}
+            nextStep={incrementCurrentStep}
+            autoplay
+            progressStatus={0}
+            isBufferVisible
+            bufferProgress={0.5}
+            pause={pausePlayback}
+            play={resumePlayback}
+            isPlaying={false}
+            vocabComplete={false}
+            vocabulary={[]}
+            getHelpIsOpen={false}
+            setGetHelpIsOpen={() => {}}
+            addPendingRemoveProps={undefined}
+          />
+        </MockAllProviders>,
+      );
+      expect(document.querySelector('.audioQuizBuffer')).toBeInTheDocument();
     });
   });
 });

--- a/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.tsx
+++ b/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.tsx
@@ -14,6 +14,10 @@ interface AudioFlashcardProps {
   nextStep: () => void;
   autoplay: boolean;
   progressStatus: number;
+  /** True when the buffer should be shown (Question, Hint, Answer only – from hook) */
+  isBufferVisible: boolean;
+  /** 0–1 progress of the buffer (for countdown bar) */
+  bufferProgress: number;
   pause: () => void;
   play: () => void;
   isPlaying: boolean;
@@ -30,6 +34,8 @@ export default function AudioFlashcardComponent({
   nextStep,
   autoplay,
   progressStatus,
+  isBufferVisible,
+  bufferProgress,
   pause,
   play,
   isPlaying,
@@ -95,6 +101,28 @@ export default function AudioFlashcardComponent({
             }}
           />
         )}
+      {autoplay && isBufferVisible && (
+        <div className="audioQuizBuffer" aria-live="polite">
+          <svg
+            className="audioQuizBufferCircle"
+            viewBox="0 0 24 24"
+            aria-hidden
+          >
+            <circle
+              className="audioQuizBufferCircleStroke"
+              cx="12"
+              cy="12"
+              r="10"
+              fill="none"
+              strokeDasharray={2 * Math.PI * 10}
+              strokeDashoffset={
+                2 * Math.PI * 10 * Math.min(bufferProgress / 0.9, 1)
+              }
+              style={{ transition: 'stroke-dashoffset 0.02s linear' }}
+            />
+          </svg>
+        </div>
+      )}
       {addPendingRemoveProps && currentStep === AudioQuizStep.Answer && (
         <div className="AddPendingRemoveButtons">
           <AddToMyFlashcardsButtons

--- a/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.tsx
+++ b/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.tsx
@@ -116,7 +116,7 @@ export default function AudioFlashcardComponent({
               fill="none"
               strokeDasharray={2 * Math.PI * 10}
               strokeDashoffset={
-                2 * Math.PI * 10 * Math.min(bufferProgress / 0.9, 1)
+                -2 * Math.PI * 10 * Math.min(bufferProgress / 0.9, 1)
               }
               style={{ transition: 'stroke-dashoffset 0.02s linear' }}
             />

--- a/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioQuiz.test.tsx
+++ b/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioQuiz.test.tsx
@@ -38,11 +38,15 @@ function MockAudioQuizWrapper({
   audioQuizType,
   autoplay,
   customCleanup,
+  isBufferVisible = false,
+  bufferProgress = 0,
 }: {
   examplesToQuiz: ExampleWithVocabulary[];
   audioQuizType: AudioQuizType;
   autoplay: boolean;
   customCleanup?: () => void;
+  isBufferVisible?: boolean;
+  bufferProgress?: number;
 }) {
   const [currentExampleIndex, setCurrentExampleIndex] = React.useState(0);
   const [currentStep, setCurrentStep] = React.useState(AudioQuizStep.Question);
@@ -119,6 +123,8 @@ function MockAudioQuizWrapper({
     previousExampleReady: currentExampleIndex > 0,
     progressStatus: 0,
     isPlaying,
+    isBufferVisible,
+    bufferProgress,
     pause,
     play,
     nextStep,
@@ -271,6 +277,27 @@ describe('component AudioQuiz', () => {
       });
     });
   });
+  describe('buffer UI', () => {
+    it('renders buffer element when isBufferVisible is true', async () => {
+      render(
+        <AudioEngineProvider>
+          <MockAudioQuizWrapper
+            examplesToQuiz={unknownAudioExamples}
+            audioQuizType={AudioQuizType.Speaking}
+            autoplay
+            isBufferVisible
+            bufferProgress={0.5}
+          />
+        </AudioEngineProvider>,
+        { wrapper: MockAllProviders },
+      );
+      await waitFor(() => {
+        expect(screen.queryByText(/Playing English/i)).toBeInTheDocument();
+      });
+      expect(document.querySelector('.audioQuizBuffer')).toBeInTheDocument();
+    });
+  });
+
   describe('autoplay', () => {
     it('autoplay is true, 2nd step is guess', async () => {
       render(

--- a/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioQuiz.tsx
+++ b/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioQuiz.tsx
@@ -91,6 +91,8 @@ export default function AudioQuiz({
     currentStep,
     autoplay,
     audioQuizType,
+    isBufferVisible,
+    bufferProgress,
     cleanupFunction,
     isQuizComplete,
     restartQuiz,
@@ -186,6 +188,8 @@ export default function AudioQuiz({
               nextStep={nextStep}
               autoplay={autoplay}
               progressStatus={progressStatus}
+              isBufferVisible={isBufferVisible}
+              bufferProgress={bufferProgress}
               pause={pause}
               play={play}
               isPlaying={isPlaying}


### PR DESCRIPTION
adds 2 second buffer to audio quiz autoplay for the following steps:
question, hint, & answer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes autoplay step-advancement timing and introduces new timer-based state, which can cause subtle race conditions if timers aren’t consistently cleared across navigation/unmount paths.
> 
> **Overview**
> Adds a **2-second buffer delay** to `useAudioQuiz` autoplay progression after `Question`/`Hint`/`Answer` audio ends (but *not* after `Guess`), exposing new `isBufferVisible` and `bufferProgress` fields and ensuring all navigation/restart/cleanup paths clear pending buffer timers.
> 
> Updates `AudioQuiz`/`AudioFlashcard` to render a small circular countdown indicator during the buffer, adds corresponding CSS, and expands mocks/tests to cover buffer timing, pause behavior during the buffer, and UI rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 662189bc5ef74e83f69d5bee0eba6c839b70a30f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->