### PR TITLE
fix double quiz_example creation

### DIFF
--- a/src/hexagon/application/useCases/useExampleAssigner/useExampleAssigner.test.ts
+++ b/src/hexagon/application/useCases/useExampleAssigner/useExampleAssigner.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   mockUseQuizExamples,
   overrideMockUseQuizExamples,
+  resetMockUseQuizExamples,
 } from '@application/queries/useQuizExamples.mock';
 import {
   mockUseStudentFlashcards,
@@ -134,6 +135,7 @@ describe('useExampleAssigner', () => {
     resetMockActiveStudent();
     resetMockUseAllQuizGroups();
     resetMockUseStudentFlashcards();
+    resetMockUseQuizExamples();
 
     // Reset all mocks to default values
     mockUseSelectedExamples.mockReturnValue({
@@ -350,7 +352,7 @@ describe('useExampleAssigner', () => {
       });
 
       expect(createFlashcardsMock).toHaveBeenCalledWith(
-        result.current.selectedExamples,
+        result.current.unassignedExamplesProps.examples,
       );
     });
 
@@ -410,8 +412,97 @@ describe('useExampleAssigner', () => {
         quizId: 1,
         quizNumber: 1,
         courseCode: 'SP101',
-        exampleIds: result.current.selectedExamples.map((ex) => ex.id),
+        exampleIds: result.current.unassignedExamplesProps.examples.map(
+          (ex) => ex.id,
+        ),
       });
+    });
+
+    it('should only send unassigned examples to quiz when some are already assigned', async () => {
+      // Assign explicit sequential IDs so the filter is deterministic regardless
+      // of the time-based factory seed (same-millisecond calls produce identical IDs).
+      const allSelectedExamples = createMockExampleWithVocabularyList(4).map(
+        (ex, i) => ({ ...ex, id: i + 1 }),
+      );
+      const alreadyAssignedExamples = allSelectedExamples.slice(0, 2);
+      const unassignedExamples = allSelectedExamples.slice(2);
+
+      const addExamplesToQuizMock = vi.fn(async () => Promise.resolve(1));
+      const quizzes = [
+        {
+          id: 1,
+          relatedQuizGroupId: 1,
+          quizNumber: 1,
+          quizTitle: 'Quiz 1',
+          published: true,
+        },
+      ];
+      const mockQuizGroups = [
+        createMockQuizGroup({
+          id: 1,
+          name: 'SP101',
+          urlSlug: 'SP101',
+          courseId: 1,
+          quizzes,
+        }),
+      ];
+
+      mockUseSelectedExamples.mockReturnValue({
+        selectedExamples: allSelectedExamples,
+        isFetchingExamples: 0,
+      });
+
+      overrideMockUseAllQuizGroups({
+        quizGroups: mockQuizGroups,
+        isLoading: false,
+        error: null,
+      });
+
+      overrideMockUseQuizExamples({
+        data: alreadyAssignedExamples,
+        isLoading: false,
+        isFetching: false,
+        error: null,
+      });
+
+      mockUseQuizExampleMutations.mockReturnValue({
+        addExamplesToQuiz: addExamplesToQuizMock,
+        isAddingExamples: false,
+        addingExamplesError: null,
+      });
+
+      const { result } = renderHook(() => useExampleAssigner(), {
+        wrapper: MockAllProviders,
+      });
+
+      act(() => {
+        result.current.assignmentTypeSelectorProps.onTypeChange('quiz');
+        result.current.quizSelectionProps.onQuizGroupIdChange(1);
+        result.current.quizSelectionProps.onQuizRecordIdChange(1);
+      });
+
+      await waitFor(() => {
+        expect(result.current.quizSelectionProps.selectedQuizRecordId).toBe(1);
+      });
+
+      await act(async () => {
+        await result.current.assignExamples();
+      });
+
+      expect(addExamplesToQuizMock).toHaveBeenCalledWith({
+        quizId: 1,
+        quizNumber: 1,
+        courseCode: 'SP101',
+        exampleIds: unassignedExamples.map((ex) => ex.id),
+      });
+
+      expect(addExamplesToQuizMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          exampleIds: expect.arrayContaining(
+            alreadyAssignedExamples.map((ex) => ex.id),
+          ),
+        }),
+      );
     });
   });
 

--- a/src/hexagon/application/useCases/useExampleAssigner/useExampleAssigner.ts
+++ b/src/hexagon/application/useCases/useExampleAssigner/useExampleAssigner.ts
@@ -208,15 +208,15 @@ export function useExampleAssigner(): UseExampleAssignerReturn {
 
   // Assignment function
   const assignExamples = useCallback(async () => {
-    if (selectedExamples.length === 0) {
-      throw new Error('No examples selected');
+    if (unassignedExamples.length === 0) {
+      throw new Error('No unassigned examples to add');
     }
 
     if (assignmentType === 'students') {
       if (!appUser?.recordId) {
         throw new Error('No active student selected');
       }
-      const createFlashcardsPromise = createFlashcards(selectedExamples);
+      const createFlashcardsPromise = createFlashcards(unassignedExamples);
       toast.promise(createFlashcardsPromise, {
         pending: 'Assigning flashcards...',
         success: 'Flashcards assigned',
@@ -227,7 +227,7 @@ export function useExampleAssigner(): UseExampleAssignerReturn {
       if (!selectedQuizRecord) {
         throw new Error('No quiz selected');
       }
-      const exampleIds = selectedExamples.map((ex) => ex.id);
+      const exampleIds = unassignedExamples.map((ex) => ex.id);
       const addExamplesToQuizPromise = addExamplesToQuiz({
         quizId: selectedQuizRecord.id,
         courseCode: selectedQuizGroup?.urlSlug || '',
@@ -242,7 +242,7 @@ export function useExampleAssigner(): UseExampleAssignerReturn {
       await addExamplesToQuizPromise;
     }
   }, [
-    selectedExamples,
+    unassignedExamples,
     assignmentType,
     appUser?.recordId,
     selectedQuizGroup,

--- a/src/hexagon/interface/components/Modal/Modal.test.tsx
+++ b/src/hexagon/interface/components/Modal/Modal.test.tsx
@@ -54,6 +54,36 @@ describe('component Modal', () => {
       });
       expect(mockProps.confirmFunction).toHaveBeenCalled();
     });
+
+    it('should disable confirm button after first click to prevent double submission', () => {
+      render(<Modal {...mockProps} type="confirm" />);
+      act(() => {
+        fireEvent.click(screen.getByText('Confirm'));
+      });
+      expect(screen.getByText('Confirm')).toBeDisabled();
+    });
+
+    it('should only call confirmFunction once even when confirm button is clicked multiple times', () => {
+      const confirmFn = vi.fn();
+      render(
+        <Modal {...mockProps} type="confirm" confirmFunction={confirmFn} />,
+      );
+      act(() => {
+        fireEvent.click(screen.getByText('Confirm'));
+        fireEvent.click(screen.getByText('Confirm'));
+        fireEvent.click(screen.getByText('Confirm'));
+      });
+      expect(confirmFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should disable accept button after first click on notice modal', () => {
+      render(<Modal {...mockProps} type="notice" />);
+      act(() => {
+        fireEvent.click(screen.getByText('Accept'));
+      });
+      expect(screen.getByText('Accept')).toBeDisabled();
+    });
+
     it('should call cancelFunction when Go Back button is clicked', () => {
       render(<Modal {...mockProps} type="confirm" />);
       act(() => {

--- a/src/hexagon/interface/components/Modal/Modal.tsx
+++ b/src/hexagon/interface/components/Modal/Modal.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import './modal.scss';
 
 export interface ModalProps {
@@ -12,8 +13,15 @@ export default function Modal(props: ModalProps) {
   const { title, body, type, confirmFunction, cancelFunction, closeModal } =
     props;
 
+  // Ref prevents double-fire within the same synchronous event cycle (before re-render).
+  // State drives the disabled attribute for the render after the first click.
+  const hasConfirmedRef = useRef(false);
+  const [isConfirming, setIsConfirming] = useState(false);
+
   function handleConfirm() {
-    if (confirmFunction) {
+    if (confirmFunction && !hasConfirmedRef.current) {
+      hasConfirmedRef.current = true;
+      setIsConfirming(true);
       confirmFunction();
     }
   }
@@ -43,14 +51,24 @@ export default function Modal(props: ModalProps) {
             >
               Go Back
             </button>
-            <button type="button" className="addButton" onClick={handleConfirm}>
+            <button
+              type="button"
+              className="addButton"
+              onClick={handleConfirm}
+              disabled={isConfirming}
+            >
               Confirm
             </button>
           </>
         );
       case 'notice':
         return (
-          <button type="button" className="addButton" onClick={handleConfirm}>
+          <button
+            type="button"
+            className="addButton"
+            onClick={handleConfirm}
+            disabled={isConfirming}
+          >
             Accept
           </button>
         );

--- a/src/hexagon/interface/components/Modal/Modal.tsx
+++ b/src/hexagon/interface/components/Modal/Modal.tsx
@@ -22,7 +22,12 @@ export default function Modal(props: ModalProps) {
     if (confirmFunction && !hasConfirmedRef.current) {
       hasConfirmedRef.current = true;
       setIsConfirming(true);
-      confirmFunction();
+      try {
+        confirmFunction();
+      } catch {
+        hasConfirmedRef.current = false;
+        setIsConfirming(false);
+      }
     }
   }
 


### PR DESCRIPTION
- added modal protection of double click to prevent double backend api call
- updated useExampleAssigner to only send unassigned examples to backend