### PR TITLE
Filter codesplit noise from Sentry; simplify Auth0 login

### DIFF
--- a/src/hexagon/infrastructure/auth/authInfrastructure.ts
+++ b/src/hexagon/infrastructure/auth/authInfrastructure.ts
@@ -64,40 +64,11 @@ export function useAuthInfrastructure(): AuthPort {
     },
 
     login: () => {
-      function generateRandomString(length: number) {
-        const charset =
-          '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz+/';
-        let result = '';
-
-        while (length > 0) {
-          const bytes = new Uint8Array(16);
-          const random = window.crypto.getRandomValues(bytes);
-
-          random.forEach((c) => {
-            if (length ? length === 0 : false) {
-              return;
-            }
-            if (c < charset.length) {
-              result += charset[c];
-              length--;
-            }
-          });
-        }
-        return result;
-      }
-
-      const randomString = generateRandomString(13);
-      const currentLocation = window.location.pathname;
-      const expiresAt = Date.now() + 300000;
-
-      const jsonToStore = JSON.stringify({
-        navigateToUrl: currentLocation,
-        expiresAt,
-      });
-      localStorage.setItem(randomString, jsonToStore);
-
+      // Auth0 persists appState through the redirect; Providers.onRedirectCallback
+      // navigates to targetUrl. Do not use localStorage — it throws SecurityError
+      // when storage is blocked (e.g. Safari private browsing) and is unused.
       loginWithRedirect({
-        appState: { targetUrl: currentLocation, state: randomString },
+        appState: { targetUrl: window.location.pathname },
       });
     },
 

--- a/src/routes/SentryRoutes.ts
+++ b/src/routes/SentryRoutes.ts
@@ -26,6 +26,14 @@ Sentry.init({
     }),
   ],
   tracesSampleRate: 1.0,
+  // Stale cached clients after deploy request hashed chunks that no longer exist.
+  // Handled by the vite:preloadError reload in index.tsx — not actionable noise.
+  ignoreErrors: [
+    /Failed to fetch dynamically imported module/,
+    /Importing a module script failed/,
+    /error loading dynamically imported module/,
+    /'text\/html' is not a valid JavaScript MIME type/,
+  ],
   denyUrls: [
     // Add URLs that shouldn't trigger Sentry
     /localhost/,


### PR DESCRIPTION
## Summary
- Ignores common post-deploy dynamic import / chunk load errors in Sentry (already handled by vite preload reload)
- Simplifies Auth0 login to pass `targetUrl` via `appState` only, removing unused localStorage state that can throw in private browsing

## Test plan
- [ ] Confirm codesplit/chunk-load errors no longer appear as new Sentry events after a deploy
- [ ] Login still redirects back to the intended path after Auth0
- [ ] Spot-check login in Safari private browsing (no storage-related crash)
- [ ] Confirm CI passes


Made with [Cursor](https://cursor.com)