### PR TITLE
Hotfix: invalidate Student Drill Down on weekly records CRUD

### DIFF
--- a/src/hexagon/application/queries/AssignmentsQueries/useAssignmentMutations.test.ts
+++ b/src/hexagon/application/queries/AssignmentsQueries/useAssignmentMutations.test.ts
@@ -2,11 +2,13 @@ import { overrideMockAssignmentsAdapter } from '@application/adapters/assignment
 import { overrideMockWeeklyRecordsAdapter } from '@application/adapters/weeklyRecordsAdapter.mock';
 import { useAssignmentsMutations } from '@application/queries/AssignmentsQueries/useAssignmentMutations';
 import { useWeeksByStartDate } from '@application/queries/useWeeksByStartDate/useWeeksByStartDate';
+import { MEMBERSHIP_WEEKS_QUERY_KEY_ROOT } from '@application/queries/WeekQueries/useMembershipWeeksQuery';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { baseAssignmentFactory } from '@testing/factories/assignmentsFactory';
 import { createMockFurnishedWeekWithCoach } from '@testing/factories/weekFactory';
 import { TestQueryClientProvider } from '@testing/providers/TestQueryClientProvider';
-import { describe, expect, it } from 'vitest';
+import { testQueryClient } from '@testing/utils/testQueryClient';
+import { describe, expect, it, vi } from 'vitest';
 
 const START_DATE = '2026-01-05';
 
@@ -238,5 +240,46 @@ describe('useAssignmentsMutations', () => {
       expect(updatedWeek?.assignments).toHaveLength(1);
       expect(updatedWeek?.assignments[0].assignmentId).toBe(20);
     });
+  });
+
+  it('should invalidate Student Drill Down membershipWeeks queries on create/update/delete', async () => {
+    const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries');
+    const assignment = baseAssignmentFactory({ weekId: 101, assignmentId: 1 });
+    overrideMockAssignmentsAdapter({
+      createAssignment: async () => assignment,
+      updateAssignment: async () => assignment,
+      deleteAssignment: async () => {},
+    });
+
+    const { result } = renderHook(() => useAssignmentsMutations(), {
+      wrapper: TestQueryClientProvider,
+    });
+
+    await act(() =>
+      result.current.createAssignmentMutation.mutateAsync(
+        makeCreateCmd(assignment),
+      ),
+    );
+    await act(() =>
+      result.current.updateAssignmentMutation.mutateAsync(
+        makeUpdateCmd(assignment),
+      ),
+    );
+    await act(() =>
+      result.current.deleteAssignmentMutation.mutateAsync({
+        assignmentId: 1,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.deleteAssignmentMutation.isSuccess).toBe(true),
+    );
+
+    const membershipWeekInvalidations = invalidateSpy.mock.calls.filter(
+      ([args]) =>
+        Array.isArray(args?.queryKey) &&
+        args.queryKey[0] === MEMBERSHIP_WEEKS_QUERY_KEY_ROOT[0],
+    );
+    expect(membershipWeekInvalidations).toHaveLength(3);
   });
 });

--- a/src/hexagon/application/queries/AssignmentsQueries/useAssignmentMutations.ts
+++ b/src/hexagon/application/queries/AssignmentsQueries/useAssignmentMutations.ts
@@ -7,6 +7,7 @@ import type {
 } from '@learncraft-spanish/shared';
 import type { UseMutationResult } from '@tanstack/react-query';
 import { useAssignmentsAdapter } from '@application/adapters/assignmentAdapter';
+import { MEMBERSHIP_WEEKS_QUERY_KEY_ROOT } from '@application/queries/WeekQueries/useMembershipWeeksQuery';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const WEEKS_QUERY_KEY = ['weeklyRecords', 'weeksByStartDate'];
@@ -50,6 +51,9 @@ export function useAssignmentsMutations(): UseAssignmentsMutationsReturn {
           });
         },
       );
+      void queryClient.invalidateQueries({
+        queryKey: MEMBERSHIP_WEEKS_QUERY_KEY_ROOT,
+      });
     },
   });
 
@@ -74,6 +78,9 @@ export function useAssignmentsMutations(): UseAssignmentsMutationsReturn {
           });
         },
       );
+      void queryClient.invalidateQueries({
+        queryKey: MEMBERSHIP_WEEKS_QUERY_KEY_ROOT,
+      });
     },
   });
 
@@ -92,6 +99,9 @@ export function useAssignmentsMutations(): UseAssignmentsMutationsReturn {
           }));
         },
       );
+      void queryClient.invalidateQueries({
+        queryKey: MEMBERSHIP_WEEKS_QUERY_KEY_ROOT,
+      });
     },
   });
 

--- a/src/hexagon/application/queries/GroupCallQueries/useGroupCallMutations.test.ts
+++ b/src/hexagon/application/queries/GroupCallQueries/useGroupCallMutations.test.ts
@@ -2,11 +2,13 @@ import { overrideMockGroupCallsAdapter } from '@application/adapters/groupCallsA
 import { overrideMockWeeklyRecordsAdapter } from '@application/adapters/weeklyRecordsAdapter.mock';
 import { useGroupCallMutations } from '@application/queries/GroupCallQueries/useGroupCallMutations';
 import { useWeeksByStartDate } from '@application/queries/useWeeksByStartDate/useWeeksByStartDate';
+import { MEMBERSHIP_WEEKS_QUERY_KEY_ROOT } from '@application/queries/WeekQueries/useMembershipWeeksQuery';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { baseGroupSessionFactory } from '@testing/factories/groupCallsFactory';
 import { createMockFurnishedWeekWithCoach } from '@testing/factories/weekFactory';
 import { TestQueryClientProvider } from '@testing/providers/TestQueryClientProvider';
-import { describe, expect, it } from 'vitest';
+import { testQueryClient } from '@testing/utils/testQueryClient';
+import { describe, expect, it, vi } from 'vitest';
 
 const START_DATE = '2026-01-05';
 
@@ -327,5 +329,49 @@ describe('useGroupCallMutations', () => {
       ).toBeDefined();
       expect(updatedWeek2?.groupCalls).toHaveLength(0);
     });
+  });
+
+  it('should invalidate Student Drill Down membershipWeeks queries on create/update/delete', async () => {
+    const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries');
+    const session = baseGroupSessionFactory({
+      groupSessionId: 1,
+      attendees: [makeAttendee(101)],
+    });
+    overrideMockGroupCallsAdapter({
+      createGroupCall: async () => session,
+      updateGroupCall: async () => session,
+      deleteGroupCall: async () => {},
+    });
+
+    const { result } = renderHook(() => useGroupCallMutations(), {
+      wrapper: TestQueryClientProvider,
+    });
+
+    await act(() =>
+      result.current.createGroupCallMutation.mutateAsync(
+        makeCreateCmd(session),
+      ),
+    );
+    await act(() =>
+      result.current.updateGroupCallMutation.mutateAsync(
+        makeUpdateCmd(session),
+      ),
+    );
+    await act(() =>
+      result.current.deleteGroupCallMutation.mutateAsync({
+        groupSessionId: 1,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.deleteGroupCallMutation.isSuccess).toBe(true),
+    );
+
+    const membershipWeekInvalidations = invalidateSpy.mock.calls.filter(
+      ([args]) =>
+        Array.isArray(args?.queryKey) &&
+        args.queryKey[0] === MEMBERSHIP_WEEKS_QUERY_KEY_ROOT[0],
+    );
+    expect(membershipWeekInvalidations).toHaveLength(3);
   });
 });

--- a/src/hexagon/application/queries/GroupCallQueries/useGroupCallMutations.ts
+++ b/src/hexagon/application/queries/GroupCallQueries/useGroupCallMutations.ts
@@ -7,8 +7,10 @@ import type {
 } from '@learncraft-spanish/shared';
 import type { UseMutationResult } from '@tanstack/react-query';
 import { useGroupCallsAdapter } from '@application/adapters/groupCallsAdapter';
+import { MEMBERSHIP_WEEKS_QUERY_KEY_ROOT } from '@application/queries/WeekQueries/useMembershipWeeksQuery';
 import { weekAttendsGroupSession } from '@domain/functions/weekAttendsGroupSession';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 const WEEKS_QUERY_KEY = ['weeklyRecords', 'weeksByStartDate'];
 
 export interface UseGroupCallMutationsReturn {
@@ -65,6 +67,9 @@ export function useGroupCallMutations(): UseGroupCallMutationsReturn {
           });
         },
       );
+      void queryClient.invalidateQueries({
+        queryKey: MEMBERSHIP_WEEKS_QUERY_KEY_ROOT,
+      });
     },
   });
 
@@ -101,6 +106,9 @@ export function useGroupCallMutations(): UseGroupCallMutationsReturn {
           });
         },
       );
+      void queryClient.invalidateQueries({
+        queryKey: MEMBERSHIP_WEEKS_QUERY_KEY_ROOT,
+      });
     },
   });
 
@@ -119,6 +127,9 @@ export function useGroupCallMutations(): UseGroupCallMutationsReturn {
           }));
         },
       );
+      void queryClient.invalidateQueries({
+        queryKey: MEMBERSHIP_WEEKS_QUERY_KEY_ROOT,
+      });
     },
   });
 

--- a/src/hexagon/application/queries/PrivateCallQueries/usePrivateCallMutations.test.ts
+++ b/src/hexagon/application/queries/PrivateCallQueries/usePrivateCallMutations.test.ts
@@ -2,11 +2,13 @@ import { overrideMockPrivateCallsAdapter } from '@application/adapters/privateCa
 import { overrideMockWeeklyRecordsAdapter } from '@application/adapters/weeklyRecordsAdapter.mock';
 import { usePrivateCallMutations } from '@application/queries/PrivateCallQueries/usePrivateCallMutations';
 import { useWeeksByStartDate } from '@application/queries/useWeeksByStartDate/useWeeksByStartDate';
+import { MEMBERSHIP_WEEKS_QUERY_KEY_ROOT } from '@application/queries/WeekQueries/useMembershipWeeksQuery';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { basePrivateCallFactory } from '@testing/factories/privateCallsFactory';
 import { createMockFurnishedWeekWithCoach } from '@testing/factories/weekFactory';
 import { TestQueryClientProvider } from '@testing/providers/TestQueryClientProvider';
-import { describe, expect, it } from 'vitest';
+import { testQueryClient } from '@testing/utils/testQueryClient';
+import { describe, expect, it, vi } from 'vitest';
 
 const START_DATE = '2026-01-05';
 
@@ -231,5 +233,40 @@ describe('usePrivateCallMutations', () => {
       expect(week?.privateCalls).toHaveLength(1);
       expect(week?.privateCalls[0].callId).toBe(20);
     });
+  });
+
+  it('should invalidate Student Drill Down membershipWeeks queries on create/update/delete', async () => {
+    const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries');
+    const call = basePrivateCallFactory({ weekId: 101, callId: 1 });
+    overrideMockPrivateCallsAdapter({
+      createPrivateCall: async () => call,
+      updatePrivateCall: async () => call,
+      deletePrivateCall: async () => {},
+    });
+
+    const { result } = renderHook(() => usePrivateCallMutations(), {
+      wrapper: TestQueryClientProvider,
+    });
+
+    await act(() =>
+      result.current.createPrivateCallMutation.mutateAsync(makeCreateCmd(call)),
+    );
+    await act(() =>
+      result.current.updatePrivateCallMutation.mutateAsync(makeUpdateCmd(call)),
+    );
+    await act(() =>
+      result.current.deletePrivateCallMutation.mutateAsync({ callId: 1 }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.deletePrivateCallMutation.isSuccess).toBe(true),
+    );
+
+    const membershipWeekInvalidations = invalidateSpy.mock.calls.filter(
+      ([args]) =>
+        Array.isArray(args?.queryKey) &&
+        args.queryKey[0] === MEMBERSHIP_WEEKS_QUERY_KEY_ROOT[0],
+    );
+    expect(membershipWeekInvalidations).toHaveLength(3);
   });
 });

--- a/src/hexagon/application/queries/PrivateCallQueries/usePrivateCallMutations.ts
+++ b/src/hexagon/application/queries/PrivateCallQueries/usePrivateCallMutations.ts
@@ -7,6 +7,7 @@ import type {
 } from '@learncraft-spanish/shared';
 import type { UseMutationResult } from '@tanstack/react-query';
 import { usePrivateCallsAdapter } from '@application/adapters/privateCallsAdapter';
+import { MEMBERSHIP_WEEKS_QUERY_KEY_ROOT } from '@application/queries/WeekQueries/useMembershipWeeksQuery';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const WEEKS_QUERY_KEY = ['weeklyRecords', 'weeksByStartDate'];
@@ -50,6 +51,9 @@ export function usePrivateCallMutations(): UsePrivateCallMutationsReturn {
           });
         },
       );
+      void queryClient.invalidateQueries({
+        queryKey: MEMBERSHIP_WEEKS_QUERY_KEY_ROOT,
+      });
     },
   });
   const updatePrivateCallMutation = useMutation({
@@ -73,6 +77,9 @@ export function usePrivateCallMutations(): UsePrivateCallMutationsReturn {
           });
         },
       );
+      void queryClient.invalidateQueries({
+        queryKey: MEMBERSHIP_WEEKS_QUERY_KEY_ROOT,
+      });
     },
   });
   const deletePrivateCallMutation = useMutation({
@@ -90,6 +97,9 @@ export function usePrivateCallMutations(): UsePrivateCallMutationsReturn {
           }));
         },
       );
+      void queryClient.invalidateQueries({
+        queryKey: MEMBERSHIP_WEEKS_QUERY_KEY_ROOT,
+      });
     },
   });
 

--- a/src/hexagon/application/queries/WeekQueries/useMembershipWeeksQuery.ts
+++ b/src/hexagon/application/queries/WeekQueries/useMembershipWeeksQuery.ts
@@ -3,8 +3,10 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { useWeeksAdapter } from '@application/adapters/weeksAdapter';
 import { useQuery } from '@tanstack/react-query';
 
+export const MEMBERSHIP_WEEKS_QUERY_KEY_ROOT = ['membershipWeeks'] as const;
+
 export const MEMBERSHIP_WEEKS_QUERY_KEY = (membershipId: number) =>
-  ['membershipWeeks', membershipId] as const;
+  [...MEMBERSHIP_WEEKS_QUERY_KEY_ROOT, membershipId] as const;
 
 export interface UseMembershipWeeksQueryReturn {
   membershipWeeksQuery: UseQueryResult<FurnishedWeek[]>;

--- a/src/hexagon/application/queries/WeekQueries/useWeekMutations.test.ts
+++ b/src/hexagon/application/queries/WeekQueries/useWeekMutations.test.ts
@@ -1,5 +1,6 @@
 import { overrideMockWeeklyRecordsAdapter } from '@application/adapters/weeklyRecordsAdapter.mock';
 import { useWeeksByStartDate } from '@application/queries/useWeeksByStartDate/useWeeksByStartDate';
+import { MEMBERSHIP_WEEKS_QUERY_KEY_ROOT } from '@application/queries/WeekQueries/useMembershipWeeksQuery';
 import { useWeekMutations } from '@application/queries/WeekQueries/useWeekMutations';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import {
@@ -8,7 +9,8 @@ import {
   createMockUpdateWeekCommand,
 } from '@testing/factories/weekFactory';
 import { TestQueryClientProvider } from '@testing/providers/TestQueryClientProvider';
-import { describe, expect, it } from 'vitest';
+import { testQueryClient } from '@testing/utils/testQueryClient';
+import { describe, expect, it, vi } from 'vitest';
 
 const START_DATE = '2026-01-05';
 
@@ -149,5 +151,30 @@ describe('useWeekMutations', () => {
     await waitFor(() =>
       expect(result.current.updateWeekMutation.isError).toBe(true),
     );
+  });
+
+  it('should invalidate Student Drill Down membershipWeeks queries on success', async () => {
+    const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries');
+    overrideMockWeeklyRecordsAdapter({
+      updateWeeks: async () => [createMockBaseWeek()],
+    });
+
+    const { result } = renderHook(() => useWeekMutations(), {
+      wrapper: TestQueryClientProvider,
+    });
+
+    await act(() =>
+      result.current.updateWeekMutation.mutateAsync([
+        createMockUpdateWeekCommand(),
+      ]),
+    );
+
+    await waitFor(() =>
+      expect(result.current.updateWeekMutation.isSuccess).toBe(true),
+    );
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: MEMBERSHIP_WEEKS_QUERY_KEY_ROOT,
+    });
   });
 });

--- a/src/hexagon/application/queries/WeekQueries/useWeekMutations.ts
+++ b/src/hexagon/application/queries/WeekQueries/useWeekMutations.ts
@@ -5,6 +5,7 @@ import type {
 } from '@learncraft-spanish/shared';
 import type { UseMutationResult } from '@tanstack/react-query';
 import { useWeeklyRecordsAdapter } from '@application/adapters/weeklyRecordsAdapter';
+import { MEMBERSHIP_WEEKS_QUERY_KEY_ROOT } from '@application/queries/WeekQueries/useMembershipWeeksQuery';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const WEEKS_QUERY_KEY = ['weeklyRecords', 'weeksByStartDate'];
@@ -39,6 +40,9 @@ export function useWeekMutations(): UseWeekMutationsReturn {
           });
         },
       );
+      void queryClient.invalidateQueries({
+        queryKey: MEMBERSHIP_WEEKS_QUERY_KEY_ROOT,
+      });
     },
   });
 


### PR DESCRIPTION
## Summary
- Invalidate Student Drill Down `membershipWeeks` queries after weekly records create/update/delete (weeks, private calls, assignments, group calls)
- Prevents stale drill-down data when Weekly Records Interface and Student Drill Down are both open
- Adds regression tests covering the invalidation

## Test plan
- [ ] Open Student Drill Down for a student with membership weeks loaded
- [ ] In Weekly Records, create/update/delete a private call, assignment, group call, and week fields
- [ ] Confirm Student Drill Down refetches and reflects the changes without a manual refresh
- [ ] CI hexagon tests pass


Made with [Cursor](https://cursor.com)