### PR TITLE
Hotfix: reduce Sentry noise from audio playback and stale chunk loads

### DIFF
--- a/src/hexagon/infrastructure/audio/audioInfrastructure.test.tsx
+++ b/src/hexagon/infrastructure/audio/audioInfrastructure.test.tsx
@@ -1,0 +1,270 @@
+import type { AudioEngine } from '@composition/context/AudioContext';
+import { AudioContext } from '@composition/context/AudioContext';
+import { useAudioInfrastructure } from '@infrastructure/audio/audioInfrastructure';
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal AudioEngine backed by a real jsdom HTMLAudioElement. */
+function makeAudioEngine() {
+  const audio = document.createElement('audio') as HTMLAudioElement;
+
+  // Plain mutable ref objects — React.RefObject<T> is just { readonly current: T },
+  // so a plain object satisfies the shape without needing useRef (a React Hook).
+  const playingAudioRef: React.RefObject<HTMLAudioElement | null> = {
+    current: audio,
+  };
+
+  const probeAudio = document.createElement('audio') as HTMLAudioElement;
+  const probeElementRef: React.RefObject<HTMLAudioElement | null> = {
+    current: probeAudio,
+  };
+
+  let probeChain: Promise<unknown> = Promise.resolve();
+  const runProbeTask = <T,>(task: () => Promise<T>): Promise<T> => {
+    const next = probeChain.then(task, task);
+    probeChain = next;
+    return next as Promise<T>;
+  };
+
+  const engine: AudioEngine = {
+    playingAudioRef,
+    probeElementRef,
+    runProbeTask,
+  };
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <AudioContext value={engine}>{children}</AudioContext>
+  );
+
+  return { audio, wrapper };
+}
+
+/** Set audio.readyState to a specific value (jsdom readyState is read-only). */
+function setReadyState(audio: HTMLAudioElement, value: number) {
+  Object.defineProperty(audio, 'readyState', { configurable: true, value });
+}
+
+/** Build a DOMException that matches a browser AbortError from interrupted play(). */
+function makeAbortError() {
+  return new DOMException(
+    'The play() request was interrupted by a call to pause().',
+    'AbortError',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAudioInfrastructure — play/pause race safety', () => {
+  /**
+   * Vitest automatically treats unhandled promise rejections as test failures,
+   * so each test below implicitly asserts "no unhandled rejection" by completing
+   * without error. Explicit isPlaying state assertions confirm the UI stays
+   * consistent with the actual playback state.
+   */
+
+  describe('safePlay — AbortError is swallowed, not rethrown', () => {
+    it('play() with a browser AbortError does not surface as an unhandled rejection', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      setReadyState(audio, 4); // HAVE_ENOUGH_DATA — takes the synchronous play() path
+      vi.spyOn(audio, 'play').mockRejectedValueOnce(makeAbortError());
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      // If safePlay did not catch AbortError, this await would propagate the
+      // rejection and vitest would fail the test automatically.
+      await act(async () => {
+        await result.current.play();
+      });
+    });
+
+    it('resets isPlaying to false when play() is interrupted (el.paused stays true)', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      setReadyState(audio, 4);
+      vi.spyOn(audio, 'play').mockRejectedValueOnce(makeAbortError());
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.play();
+      });
+
+      // isPlaying was optimistically set true, but after the AbortError the
+      // paused-element check resets it to false.
+      expect(result.current.isPlaying).toBe(false);
+    });
+
+    it('keeps isPlaying true when play() resolves and audio is actually playing', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      setReadyState(audio, 4);
+      vi.spyOn(audio, 'play').mockResolvedValueOnce(undefined);
+      // jsdom does not actually play audio, so simulate el.paused === false
+      Object.defineProperty(audio, 'paused', {
+        configurable: true,
+        get: () => false,
+      });
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.play();
+      });
+
+      expect(result.current.isPlaying).toBe(true);
+    });
+  });
+
+  describe('abortController — stale listener cancellation', () => {
+    it('cancels a pending loadedmetadata listener when changeCurrentAudio is called', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      // readyState 0 → play() queues a loadedmetadata listener instead of calling el.play() directly
+      setReadyState(audio, 0);
+      const playSpy = vi.spyOn(audio, 'play').mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.play();
+      });
+      // The loadedmetadata listener is registered but hasn't fired yet
+      expect(playSpy).not.toHaveBeenCalled();
+
+      // changeCurrentAudio() calls startNewOperation() which aborts the pending listener
+      await act(async () => {
+        await result.current.changeCurrentAudio({
+          currentTime: 0,
+          src: 'https://example.com/new.mp3',
+          onEnded: vi.fn(),
+          playOnLoad: false,
+        });
+      });
+
+      // Simulate the browser firing 'loadedmetadata' for the old source —
+      // the stale listener should be silently cancelled (signal was aborted)
+      await act(async () => {
+        audio.dispatchEvent(new Event('loadedmetadata'));
+      });
+
+      expect(playSpy).not.toHaveBeenCalled();
+    });
+
+    it('only the second loadeddata listener fires when changeCurrentAudio is called twice rapidly', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      setReadyState(audio, 4);
+      const playSpy = vi.spyOn(audio, 'play').mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      // Call changeCurrentAudio twice in the same act — the first call's loadeddata
+      // listener should be cancelled by the second call's startNewOperation().
+      await act(async () => {
+        await result.current.changeCurrentAudio({
+          currentTime: 0,
+          src: 'https://example.com/first.mp3',
+          onEnded: vi.fn(),
+          playOnLoad: true,
+        });
+        await result.current.changeCurrentAudio({
+          currentTime: 0,
+          src: 'https://example.com/second.mp3',
+          onEnded: vi.fn(),
+          playOnLoad: true,
+        });
+      });
+
+      // Dispatch loadeddata once — only the second call's listener is still active
+      await act(async () => {
+        audio.dispatchEvent(new Event('loadeddata'));
+      });
+
+      // Exactly one play() call from the surviving (second) listener
+      expect(playSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels a pending loadedmetadata listener when pause() is called before metadata loads', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      setReadyState(audio, 0);
+      const playSpy = vi.spyOn(audio, 'play').mockResolvedValue(undefined);
+      vi.spyOn(audio, 'pause').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.play();
+      });
+      // Listener registered, isPlaying optimistically true
+      expect(result.current.isPlaying).toBe(true);
+
+      await act(async () => {
+        await result.current.pause();
+      });
+
+      // Firing loadedmetadata now must NOT trigger play() since the listener was cancelled
+      await act(async () => {
+        audio.dispatchEvent(new Event('loadedmetadata'));
+      });
+
+      expect(playSpy).not.toHaveBeenCalled();
+      expect(result.current.isPlaying).toBe(false);
+    });
+  });
+
+  describe('rapid play/pause — isPlaying state consistency', () => {
+    it('ends with isPlaying false when play() is immediately followed by pause()', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      setReadyState(audio, 4);
+
+      let resolvePlay!: () => void;
+      // play() returns a long-running promise so we can call pause() before it resolves
+      vi.spyOn(audio, 'play').mockImplementation(
+        () =>
+          new Promise<undefined>((res) => {
+            resolvePlay = res as () => void;
+          }),
+      );
+      vi.spyOn(audio, 'pause').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      // Start play — promise is pending
+      act(() => {
+        result.current.play().catch(() => {});
+      });
+
+      // Immediately pause — aborts the pending operation
+      await act(async () => {
+        await result.current.pause();
+      });
+
+      // Resolve play (simulating AbortError would happen in real browser; here we
+      // just resolve to exercise the el.paused check path)
+      await act(async () => {
+        resolvePlay();
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // Final state must be paused regardless of the play() resolution order
+      expect(result.current.isPlaying).toBe(false);
+    });
+  });
+});

--- a/src/hexagon/infrastructure/audio/audioInfrastructure.test.tsx
+++ b/src/hexagon/infrastructure/audio/audioInfrastructure.test.tsx
@@ -266,5 +266,93 @@ describe('useAudioInfrastructure — play/pause race safety', () => {
       // Final state must be paused regardless of the play() resolution order
       expect(result.current.isPlaying).toBe(false);
     });
+
+    it('does not stomp isPlaying when changeCurrentAudio supersedes an in-flight play()', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      setReadyState(audio, 4);
+
+      let resolvePlay!: () => void;
+      vi.spyOn(audio, 'play').mockImplementation(
+        () =>
+          new Promise<undefined>((res) => {
+            resolvePlay = res as () => void;
+          }),
+      );
+      vi.spyOn(audio, 'pause').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      // Start play — safePlay promise is pending after optimistic setIsPlaying(true)
+      act(() => {
+        result.current.play().catch(() => {});
+      });
+      expect(result.current.isPlaying).toBe(true);
+
+      // Superseding operation wants playback (playOnLoad) but new audio has not
+      // started yet, so el.paused remains true — the stale play() continuation
+      // must not reset isPlaying to false.
+      await act(async () => {
+        await result.current.changeCurrentAudio({
+          currentTime: 0,
+          src: 'https://example.com/next.mp3',
+          onEnded: vi.fn(),
+          playOnLoad: true,
+        });
+      });
+      expect(result.current.isPlaying).toBe(true);
+
+      await act(async () => {
+        resolvePlay();
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(result.current.isPlaying).toBe(true);
+    });
+
+    it('does not stomp isPlaying when changeCurrentAudio supersedes after loadedmetadata', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      setReadyState(audio, 0);
+
+      let resolvePlay!: () => void;
+      vi.spyOn(audio, 'play').mockImplementation(
+        () =>
+          new Promise<undefined>((res) => {
+            resolvePlay = res as () => void;
+          }),
+      );
+      vi.spyOn(audio, 'pause').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.play();
+      });
+
+      // Fire loadedmetadata so safePlay starts; leave the promise pending.
+      await act(async () => {
+        audio.dispatchEvent(new Event('loadedmetadata'));
+      });
+
+      await act(async () => {
+        await result.current.changeCurrentAudio({
+          currentTime: 0,
+          src: 'https://example.com/next.mp3',
+          onEnded: vi.fn(),
+          playOnLoad: true,
+        });
+      });
+      expect(result.current.isPlaying).toBe(true);
+
+      await act(async () => {
+        resolvePlay();
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(result.current.isPlaying).toBe(true);
+    });
   });
 });

--- a/src/hexagon/infrastructure/audio/audioInfrastructure.test.tsx
+++ b/src/hexagon/infrastructure/audio/audioInfrastructure.test.tsx
@@ -124,6 +124,27 @@ describe('useAudioInfrastructure — play/pause race safety', () => {
 
       expect(result.current.isPlaying).toBe(true);
     });
+
+    it('primeAudioElement routes through safePlay (no unhandled rejection on AbortError)', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      const playSpy = vi
+        .spyOn(audio, 'play')
+        .mockRejectedValueOnce(makeAbortError());
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      await act(async () => {
+        result.current.primeAudioElement('https://example.com/silence.mp3');
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(audio.src).toContain('silence.mp3');
+      expect(playSpy).toHaveBeenCalledTimes(1);
+      // Priming must not flip quiz UI playing state
+      expect(result.current.isPlaying).toBe(false);
+    });
   });
 
   describe('abortController — stale listener cancellation', () => {
@@ -224,6 +245,82 @@ describe('useAudioInfrastructure — play/pause race safety', () => {
 
       expect(playSpy).not.toHaveBeenCalled();
       expect(result.current.isPlaying).toBe(false);
+    });
+
+    it('resets isPlaying when changeCurrentAudio playOnLoad fails and element stays paused', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      setReadyState(audio, 4);
+      vi.spyOn(audio, 'play').mockRejectedValueOnce(makeAbortError());
+      vi.spyOn(audio, 'pause').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.changeCurrentAudio({
+          currentTime: 0,
+          src: 'https://example.com/next.mp3',
+          onEnded: vi.fn(),
+          playOnLoad: true,
+        });
+      });
+      expect(result.current.isPlaying).toBe(true);
+
+      await act(async () => {
+        audio.dispatchEvent(new Event('loadeddata'));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(result.current.isPlaying).toBe(false);
+    });
+
+    it('keeps isPlaying true when a newer changeCurrentAudio supersedes a failed playOnLoad', async () => {
+      const { audio, wrapper } = makeAudioEngine();
+      setReadyState(audio, 4);
+
+      let resolveFirstPlay!: () => void;
+      vi.spyOn(audio, 'play').mockImplementationOnce(
+        () =>
+          new Promise<undefined>((res) => {
+            resolveFirstPlay = res as () => void;
+          }),
+      );
+      vi.spyOn(audio, 'pause').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useAudioInfrastructure(), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.changeCurrentAudio({
+          currentTime: 0,
+          src: 'https://example.com/first.mp3',
+          onEnded: vi.fn(),
+          playOnLoad: true,
+        });
+      });
+
+      await act(async () => {
+        audio.dispatchEvent(new Event('loadeddata'));
+      });
+
+      await act(async () => {
+        await result.current.changeCurrentAudio({
+          currentTime: 0,
+          src: 'https://example.com/second.mp3',
+          onEnded: vi.fn(),
+          playOnLoad: true,
+        });
+      });
+      expect(result.current.isPlaying).toBe(true);
+
+      await act(async () => {
+        resolveFirstPlay();
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(result.current.isPlaying).toBe(true);
     });
   });
 

--- a/src/hexagon/infrastructure/audio/audioInfrastructure.ts
+++ b/src/hexagon/infrastructure/audio/audioInfrastructure.ts
@@ -51,12 +51,15 @@ export function useAudioInfrastructure(): AudioPort {
   // addEventListener listener registered with its signal is automatically cancelled,
   // preventing stale loadedmetadata / loadeddata callbacks from calling safePlay
   // on a superseded audio element state.
-  const operationAbortControllerRef = useRef(new AbortController());
+  const operationAbortControllerRef = useRef<AbortController | null>(null);
+  if (!operationAbortControllerRef.current) {
+    operationAbortControllerRef.current = new AbortController();
+  }
 
   // Abort the current operation and return a fresh signal for the next one.
   // Stable identity (empty deps): only reads/writes the ref, which is always the same object.
   const startNewOperation = useCallback((): AbortSignal => {
-    operationAbortControllerRef.current.abort();
+    operationAbortControllerRef.current!.abort();
     const next = new AbortController();
     operationAbortControllerRef.current = next;
     return next.signal;
@@ -91,6 +94,10 @@ export function useAudioInfrastructure(): AudioPort {
         'loadedmetadata',
         () => {
           safePlay(el).then(() => {
+            // If a newer operation superseded this one while play() was in flight
+            // (e.g. changeCurrentAudio set isPlaying true and is waiting on loadeddata),
+            // do not stomp that optimistic state just because el is still paused.
+            if (signal.aborted) return;
             // If playback was aborted or failed for a non-AbortError reason,
             // reset the UI so it doesn't show "playing" when nothing is playing.
             if (el.paused) setIsPlaying(false);
@@ -103,8 +110,9 @@ export function useAudioInfrastructure(): AudioPort {
 
     setIsPlaying(true);
     await safePlay(el);
-    // If pause()/changeCurrentAudio() raced and already corrected isPlaying, this is a
-    // no-op. If playback failed for another reason, reset to avoid a stuck "playing" UI.
+    // Same supersession guard as the loadedmetadata path above.
+    if (signal.aborted) return;
+    // If playback failed for another reason, reset to avoid a stuck "playing" UI.
     if (el.paused) setIsPlaying(false);
   }, [playingAudioRef, isPlaying, startNewOperation]);
 

--- a/src/hexagon/infrastructure/audio/audioInfrastructure.ts
+++ b/src/hexagon/infrastructure/audio/audioInfrastructure.ts
@@ -3,7 +3,35 @@ import type {
   AudioPort,
 } from '@application/ports/audioPort';
 import { AudioContext } from '@composition/context/AudioContext';
+import * as Sentry from '@sentry/react';
 import { use, useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Calls el.play() synchronously (preserving the browser user-gesture token),
+ * then catches expected interruption errors so they never become unhandled rejections.
+ *
+ * AbortError is an expected race (pause/load called before play resolves) — recorded
+ * as a breadcrumb only so the fix can be validated in Sentry without generating noise.
+ *
+ * Any other error is unexpected (e.g. NotSupportedError, NotAllowedError) and is
+ * captured as a warning-level Sentry event for investigation, but still not rethrown
+ * so it cannot break the UX.
+ */
+function safePlay(el: HTMLMediaElement): Promise<void> {
+  return el.play().catch((error: unknown) => {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      Sentry.addBreadcrumb({
+        category: 'audio',
+        message:
+          'play() interrupted (AbortError) — expected race with pause/load',
+        level: 'warning',
+        data: { src: el.src },
+      });
+      return;
+    }
+    Sentry.captureException(error, { level: 'warning' });
+  });
+}
 
 export function useAudioInfrastructure(): AudioPort {
   const context = use(AudioContext);
@@ -17,6 +45,22 @@ export function useAudioInfrastructure(): AudioPort {
   const [isPlaying, setIsPlaying] = useState(false);
   // State for the current time of the playing audio
   const [currentTime, setCurrentTime] = useState(0);
+
+  // One AbortController tracks the "current audio operation" (play / changeCurrentAudio /
+  // pause / cleanup). Every new operation aborts the previous one so that any
+  // addEventListener listener registered with its signal is automatically cancelled,
+  // preventing stale loadedmetadata / loadeddata callbacks from calling safePlay
+  // on a superseded audio element state.
+  const operationAbortControllerRef = useRef(new AbortController());
+
+  // Abort the current operation and return a fresh signal for the next one.
+  // Stable identity (empty deps): only reads/writes the ref, which is always the same object.
+  const startNewOperation = useCallback((): AbortSignal => {
+    operationAbortControllerRef.current.abort();
+    const next = new AbortController();
+    operationAbortControllerRef.current = next;
+    return next.signal;
+  }, []);
 
   // Unlocks the audio element for programmatic playback.
   // Must be called synchronously from a user gesture (e.g. "Start Quiz" click).
@@ -33,32 +77,50 @@ export function useAudioInfrastructure(): AudioPort {
     // If the audio element is not mounted or is already playing, do nothing
     if (!playingAudioRef.current || isPlaying) {
       return;
-    } else if (playingAudioRef.current.readyState < 1) {
-      // If the audio is not ready to be played, play it when the metadata is loaded
+    }
+
+    const el = playingAudioRef.current;
+    // Abort any previous pending loadedmetadata listener from an earlier play() call
+    // that hasn't fired yet (e.g. double-click play before readyState advances).
+    const signal = startNewOperation();
+
+    if (el.readyState < 1) {
+      // Audio not yet loaded: optimistically mark as playing, then start when metadata arrives.
       setIsPlaying(true);
-      playingAudioRef.current.addEventListener(
+      el.addEventListener(
         'loadedmetadata',
         () => {
-          playingAudioRef.current?.play();
+          safePlay(el).then(() => {
+            // If playback was aborted or failed for a non-AbortError reason,
+            // reset the UI so it doesn't show "playing" when nothing is playing.
+            if (el.paused) setIsPlaying(false);
+          });
         },
-        { once: true },
+        { once: true, signal },
       );
       return;
     }
+
     setIsPlaying(true);
-    await playingAudioRef.current.play();
-  }, [playingAudioRef, isPlaying, setIsPlaying]);
+    await safePlay(el);
+    // If pause()/changeCurrentAudio() raced and already corrected isPlaying, this is a
+    // no-op. If playback failed for another reason, reset to avoid a stuck "playing" UI.
+    if (el.paused) setIsPlaying(false);
+  }, [playingAudioRef, isPlaying, startNewOperation]);
 
   const pause = useCallback(async () => {
     // If the audio is not playing, do nothing
     if (!playingAudioRef.current || !isPlaying) return;
+    // Cancel any pending loadedmetadata/loadeddata listener so audio cannot start
+    // playing again after this pause (e.g. if readyState was < 1 when play() was called).
+    startNewOperation();
     // Pause the audio
-    await playingAudioRef.current.pause();
+    playingAudioRef.current.pause();
     // Stop the UI update propagation
     if (tickRef.current) clearInterval(tickRef.current);
     // UI state update
     setIsPlaying(false);
-  }, [playingAudioRef, isPlaying, setIsPlaying]);
+  }, [playingAudioRef, isPlaying, startNewOperation]);
 
   // Updates the current time state of the playing audio
   const updateCurrentTime = useCallback(() => {
@@ -76,25 +138,28 @@ export function useAudioInfrastructure(): AudioPort {
 
       const el = playingAudioRef.current;
 
-      // Stop current playback and clear pending listeners on the SAME element
-      // (preserves the user-gesture permission chain — never clone/replace)
+      // Cancel any pending loadedmetadata/loadeddata listener from a previous play() or
+      // changeCurrentAudio() call, then stop current playback — all on the SAME element
+      // to preserve the user-gesture permission chain (never clone/replace the element).
+      const signal = startNewOperation();
       el.pause();
-      el.onloadedmetadata = null;
       el.onended = null;
 
       el.src = newAudio.src;
       el.onended = newAudio.onEnded;
 
-      // Use loadeddata (first frame available) to start playback as early as possible when switching sources
+      // Use loadeddata (first frame available) to start playback as early as possible
+      // when switching sources. The { signal } ensures this listener is cancelled if
+      // another changeCurrentAudio() call supersedes this one before loadeddata fires.
       el.addEventListener(
         'loadeddata',
         () => {
           el.currentTime = newAudio.currentTime;
           if (newAudio.playOnLoad) {
-            el.play();
+            safePlay(el);
           }
         },
-        { once: true },
+        { once: true, signal },
       );
 
       setIsPlaying(newAudio.playOnLoad);
@@ -102,13 +167,14 @@ export function useAudioInfrastructure(): AudioPort {
 
       updateCurrentTime();
     },
-    [playingAudioRef, updateCurrentTime],
+    [playingAudioRef, startNewOperation, updateCurrentTime],
   );
 
   const cleanupAudio = useCallback(() => {
+    // Cancel all pending listeners before touching the element.
+    startNewOperation();
     if (playingAudioRef.current) {
       playingAudioRef.current.pause();
-      playingAudioRef.current.onloadedmetadata = null;
       playingAudioRef.current.onended = null;
       playingAudioRef.current.currentTime = 0;
       playingAudioRef.current.src = '';
@@ -121,7 +187,7 @@ export function useAudioInfrastructure(): AudioPort {
 
     setIsPlaying(false);
     setCurrentTime(0);
-  }, [playingAudioRef]);
+  }, [playingAudioRef, startNewOperation]);
 
   // Ticks the current time of the playing audio, pushes to state
   useEffect(() => {

--- a/src/hexagon/infrastructure/audio/audioInfrastructure.ts
+++ b/src/hexagon/infrastructure/audio/audioInfrastructure.ts
@@ -71,7 +71,10 @@ export function useAudioInfrastructure(): AudioPort {
     (silenceUrl: string) => {
       if (!playingAudioRef.current) return;
       playingAudioRef.current.src = silenceUrl;
-      playingAudioRef.current.play().catch(() => {});
+      // safePlay still invokes play() synchronously (preserves the gesture token)
+      // and reports unexpected failures — especially NotAllowedError, which is the
+      // autoplay-policy case this unlock exists to prevent.
+      void safePlay(playingAudioRef.current);
     },
     [playingAudioRef],
   );
@@ -164,7 +167,12 @@ export function useAudioInfrastructure(): AudioPort {
         () => {
           el.currentTime = newAudio.currentTime;
           if (newAudio.playOnLoad) {
-            safePlay(el);
+            // Same post-play guard as play(): optimistic isPlaying(true) must be
+            // corrected if playback fails and no newer operation has superseded us.
+            safePlay(el).then(() => {
+              if (signal.aborted) return;
+              if (el.paused) setIsPlaying(false);
+            });
           }
         },
         { once: true, signal },

--- a/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.test.tsx
+++ b/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.test.tsx
@@ -7,8 +7,8 @@ import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const incrementCurrentStep = vi.fn(() => {});
-const pausePlayback = vi.fn(() => {});
-const resumePlayback = vi.fn(() => {});
+const pausePlayback = vi.fn(() => Promise.resolve());
+const resumePlayback = vi.fn(() => Promise.resolve());
 
 const addFlashcard = vi.fn(() => {});
 const removeFlashcard = vi.fn(() => {});

--- a/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.tsx
+++ b/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.tsx
@@ -14,8 +14,8 @@ interface AudioFlashcardProps {
   nextStep: () => void;
   autoplay: boolean;
   progressStatus: number;
-  pause: () => void;
-  play: () => void;
+  pause: () => Promise<void>;
+  play: () => Promise<void>;
   isPlaying: boolean;
   getHelpIsOpen: boolean;
   setGetHelpIsOpen: (getHelpIsOpen: boolean) => void;
@@ -42,9 +42,9 @@ export default function AudioFlashcardComponent({
   ): void {
     e.stopPropagation();
     if (isPlaying) {
-      pause();
+      pause().catch(() => {});
     } else {
-      play();
+      play().catch(() => {});
     }
   }
 

--- a/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.tsx
+++ b/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioFlashcard.tsx
@@ -42,9 +42,9 @@ export default function AudioFlashcardComponent({
   ): void {
     e.stopPropagation();
     if (isPlaying) {
-      pause().catch(() => {});
+      pause();
     } else {
-      play().catch(() => {});
+      play();
     }
   }
 

--- a/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioQuiz.tsx
+++ b/src/hexagon/interface/components/Quizzing/AudioQuiz/AudioQuiz.tsx
@@ -121,9 +121,9 @@ export default function AudioQuiz({
       } else if (event.key === ' ') {
         event.preventDefault();
         if (isPlaying) {
-          pause();
+          pause().catch(() => {});
         } else {
-          play();
+          play().catch(() => {});
         }
       }
       if (getHelpIsOpen) {

--- a/src/routes/SentryRoutes.ts
+++ b/src/routes/SentryRoutes.ts
@@ -9,6 +9,7 @@ import {
   useLocation,
   useNavigationType,
 } from 'react-router-dom';
+import { shouldIgnoreError } from './sentryIgnoredErrors';
 
 const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 
@@ -32,6 +33,13 @@ Sentry.init({
   ],
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
+  beforeSend: (event, hint) => {
+    if (shouldIgnoreError(event, hint.originalException)) {
+      return null;
+    }
+
+    return event;
+  },
 });
 
 export default SentryRoutes;

--- a/src/routes/sentryIgnoredErrors.test.ts
+++ b/src/routes/sentryIgnoredErrors.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { shouldIgnoreError } from './sentryIgnoredErrors';
+
+describe('shouldIgnoreError', () => {
+  it('ignores failed dynamic import TypeErrors from originalException', () => {
+    const error = new TypeError(
+      'Failed to fetch dynamically imported module: https://app.learncraftspanish.com/assets/WeeksRecords-Bf5e4mps.js',
+    );
+
+    expect(shouldIgnoreError({}, error)).toBe(true);
+  });
+
+  it('ignores the same error when only present on the Sentry event payload', () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value:
+              'Failed to fetch dynamically imported module: https://app.learncraftspanish.com/assets/WeeksRecords-Bf5e4mps.js',
+          },
+        ],
+      },
+    };
+
+    expect(shouldIgnoreError(event, undefined)).toBe(true);
+  });
+
+  it('ignores when the ignored error is nested as cause', () => {
+    const cause = new TypeError(
+      'Failed to fetch dynamically imported module: https://app.learncraftspanish.com/assets/foo.js',
+    );
+    const error = new Error('wrapper', { cause });
+
+    expect(shouldIgnoreError({}, error)).toBe(true);
+  });
+
+  it('ignores Firefox dynamically imported module TypeErrors', () => {
+    const error = new TypeError(
+      'error loading dynamically imported module: https://app.learncraftspanish.com/assets/CombinedCustomQuiz-CQzRiShA.js',
+    );
+
+    expect(shouldIgnoreError({}, error)).toBe(true);
+  });
+
+  it('ignores invalid JavaScript MIME type TypeErrors', () => {
+    expect(
+      shouldIgnoreError(
+        {},
+        new TypeError("'text/html' is not a valid JavaScript MIME type."),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not ignore unrelated TypeErrors', () => {
+    expect(
+      shouldIgnoreError({}, new TypeError('Cannot read properties of null')),
+    ).toBe(false);
+  });
+});

--- a/src/routes/sentryIgnoredErrors.ts
+++ b/src/routes/sentryIgnoredErrors.ts
@@ -1,0 +1,82 @@
+/**
+ * Errors that should not be sent to Sentry.
+ * Prefer exact name + message when stable; use a RegExp message when the
+ * text includes volatile parts (e.g. hashed asset URLs after a deploy).
+ */
+export interface IgnoredError {
+  name: string;
+  message: string | RegExp;
+}
+
+export const errorsToIgnore: IgnoredError[] = [
+  // Stale tab after deploy: browser can't load a hashed chunk that no longer exists.
+  {
+    name: 'TypeError',
+    message: /^Failed to fetch dynamically imported module:/,
+  },
+  // Firefox variant of the same stale-chunk failure.
+  {
+    name: 'TypeError',
+    message: /^error loading dynamically imported module:/,
+  },
+  // Deploy/CDN returned HTML (e.g. index/404) instead of the JS chunk.
+  {
+    name: 'TypeError',
+    message: "'text/html' is not a valid JavaScript MIME type.",
+  },
+];
+
+interface ErrorLike {
+  name?: string;
+  message?: string;
+  cause?: unknown;
+}
+
+const matchesIgnoredError = (errorLike: unknown): boolean => {
+  if (!errorLike || typeof errorLike !== 'object') {
+    return false;
+  }
+
+  const { name, message } = errorLike as ErrorLike;
+  if (typeof name !== 'string' || typeof message !== 'string') {
+    return false;
+  }
+
+  return errorsToIgnore.some((candidate) => {
+    if (candidate.name !== name) {
+      return false;
+    }
+
+    return typeof candidate.message === 'string'
+      ? candidate.message === message
+      : candidate.message.test(message);
+  });
+};
+
+export const shouldIgnoreError = (
+  event: { exception?: { values?: Array<{ type?: string; value?: string }> } },
+  originalException: unknown,
+): boolean => {
+  if (matchesIgnoredError(originalException)) {
+    return true;
+  }
+
+  const cause =
+    originalException &&
+    typeof originalException === 'object' &&
+    'cause' in originalException
+      ? (originalException as ErrorLike).cause
+      : undefined;
+
+  if (matchesIgnoredError(cause)) {
+    return true;
+  }
+
+  const eventExceptions = event.exception?.values ?? [];
+  return eventExceptions.some((exception) =>
+    matchesIgnoredError({
+      name: exception.type,
+      message: exception.value,
+    }),
+  );
+};

--- a/src/routes/sentryIgnoredErrors.ts
+++ b/src/routes/sentryIgnoredErrors.ts
@@ -22,7 +22,7 @@ export const errorsToIgnore: IgnoredError[] = [
   // Deploy/CDN returned HTML (e.g. index/404) instead of the JS chunk.
   {
     name: 'TypeError',
-    message: "'text/html' is not a valid JavaScript MIME type.",
+    message: /is not a valid JavaScript MIME type/,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Soften audio play/pause failures so expected playback issues are breadcrumbs/warnings instead of noisy Sentry errors.
- Add frontend Sentry `beforeSend` ignore-list infra (mirrors the API) to drop known post-deploy chunk-load noise:
  - `Failed to fetch dynamically imported module`
  - `error loading dynamically imported module`
  - `'text/html' is not a valid JavaScript MIME type`

## Test plan
- [ ] Confirm ignored errors are dropped locally by triggering/inspecting `beforeSend` behavior (or unit tests for `shouldIgnoreError`)
- [ ] Smoke-test audio quiz play/pause; verify expected failures no longer create error-level Sentry events
- [ ] After merge/deploy, confirm the three ignored issue types stop appearing in the frontend Sentry project


Made with [Cursor](https://cursor.com)