### PR TITLE
feat: migrate Private Calls by Coach report to hexagon

### DIFF
--- a/lockfiles/ci/pnpm-lock.yaml
+++ b/lockfiles/ci/pnpm-lock.yaml
@@ -3927,8 +3927,8 @@ packages:
       node-notifier:
         optional: true
 
-  jose@6.2.5:
-    resolution: {integrity: sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==}
+  jose@6.2.6:
+    resolution: {integrity: sha512-HwMtbJjMw8rC8dUTwCNilHJD+fxTeKM3JV1eprSmTjS41qwXSSt6exJXgyPK1QOu0jB9eDYLESRDkB3qaT3jnw==}
 
   js-md4@0.3.2:
     resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
@@ -3942,12 +3942,12 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@4.1.0:
@@ -5858,7 +5858,7 @@ snapshots:
 
   '@auth0/auth0-auth-js@1.12.0':
     dependencies:
-      jose: 6.2.5
+      jose: 6.2.6
       openid-client: 6.8.4
 
   '@auth0/auth0-react@2.22.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
@@ -6617,7 +6617,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6824,7 +6824,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -10214,7 +10214,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jose@6.2.5: {}
+  jose@6.2.6: {}
 
   js-md4@0.3.2: {}
 
@@ -10224,12 +10224,12 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -10932,7 +10932,7 @@ snapshots:
 
   openid-client@6.8.4:
     dependencies:
-      jose: 6.2.5
+      jose: 6.2.6
       oauth4webapi: 3.8.6
 
   optionator@0.9.4:

--- a/src/components/AdminDashboard/CallsByCoach/CallsByCoach.tsx
+++ b/src/components/AdminDashboard/CallsByCoach/CallsByCoach.tsx
@@ -1,58 +1,26 @@
+import { useState } from 'react';
 import DeprecatedSectionHeader from '../DeprecatedSectionHeader';
+import PrivateCallsByCoach from './PrivateCallsByCoach';
 
-/* Deprecated — re-enable when admin reports are migrated to hexagon.
-import { useEffect, useState } from 'react';
+/* Deprecated — re-enable when group calls and calls drilldown are migrated.
+import { useEffect } from 'react';
 import GroupCallsByCoach from './GroupCallsByCoach';
 import GroupCallsDrilldownTable from './GroupCallsDrilldownTable';
-import PrivateCallsByCoach from './PrivateCallsByCoach';
 import PrivateCallsDrilldownTable from './PrivateCallsDrilldownTable';
-
-export default function CallsByCoach() {
-  const [selectedReport, setSelectedReport] = useState<string | null>(null);
-  const [groupCallsByCoachOpen, setGroupCallsByCoachOpen] = useState(false);
-  const [privateCallsByCoachOpen, setPrivateCallsByCoachOpen] = useState(false);
-
-  const updateSelectedReport = (str: string) => {
-    setSelectedReport(str);
-  };
-
-  useEffect(() => {
-    if (!groupCallsByCoachOpen && !privateCallsByCoachOpen) {
-      setSelectedReport(null);
-    }
-  }, [groupCallsByCoachOpen, privateCallsByCoachOpen]);
-
-  return (
-    <div className="section-with-interactive-table">
-      <div className="admin-dashboard-grid">
-        <GroupCallsByCoach
-          setSelectedReport={updateSelectedReport}
-          isOpen={groupCallsByCoachOpen}
-          setIsOpen={setGroupCallsByCoachOpen}
-        />
-        <PrivateCallsByCoach
-          setSelectedReport={updateSelectedReport}
-          isOpen={privateCallsByCoachOpen}
-          setIsOpen={setPrivateCallsByCoachOpen}
-        />
-      </div>
-      {selectedReport?.includes('Group') && (
-        <GroupCallsDrilldownTable selectedReport={selectedReport} />
-      )}
-      {selectedReport?.includes('Calls') && (
-        <PrivateCallsDrilldownTable selectedReport={selectedReport} />
-      )}
-    </div>
-  );
-}
 */
 
 export default function CallsByCoach() {
+  const [privateCallsByCoachOpen, setPrivateCallsByCoachOpen] = useState(false);
+
   return (
     <div className="section-with-interactive-table">
       <div className="admin-dashboard-grid">
         <DeprecatedSectionHeader title="Group Calls by Coach" />
-        <DeprecatedSectionHeader title="Private Calls by Coach" />
+        <PrivateCallsByCoach
+          setSelectedReport={() => undefined}
+          isOpen={privateCallsByCoachOpen}
+          setIsOpen={setPrivateCallsByCoachOpen}
+        />
       </div>
     </div>
   );

--- a/src/components/AdminDashboard/CallsByCoach/PrivateCallsByCoach/types.ts
+++ b/src/components/AdminDashboard/CallsByCoach/PrivateCallsByCoach/types.ts
@@ -1,6 +1,3 @@
-interface PrivateCallData {
-  caller: string;
-  numberOfCalls: number;
-}
+import type { PrivateCallsByCoach } from '@learncraft-spanish/shared';
 
-export type { PrivateCallData };
+export type { PrivateCallsByCoach as PrivateCallData };

--- a/src/hexagon/application/adapters/AdminReports/adminReportsAdapter.mock.ts
+++ b/src/hexagon/application/adapters/AdminReports/adminReportsAdapter.mock.ts
@@ -10,6 +10,7 @@ const defaultMockAdminReportsAdapter: AdminReportsPort = {
   getWeeklyCoachSummaryReport: async () => [],
   getLastWeekCoachSummaryReport: async () => [],
   getWeeksDrilldownReport: async () => [],
+  getPrivateCallsByCoachReport: async () => [],
 };
 
 export const {

--- a/src/hexagon/application/ports/AdminReports/adminReportsPort.ts
+++ b/src/hexagon/application/ports/AdminReports/adminReportsPort.ts
@@ -3,6 +3,7 @@ import type {
   CoachSummary,
   CoachSummaryDrilldown,
   MembershipsByCoach,
+  PrivateCallsByCoach,
 } from '@learncraft-spanish/shared';
 
 export type WeeksDrilldownReportName =
@@ -26,4 +27,5 @@ export interface AdminReportsPort {
     coachName: string,
     report: WeeksDrilldownReportName,
   ) => Promise<CoachSummaryDrilldown[]>;
+  getPrivateCallsByCoachReport: () => Promise<PrivateCallsByCoach[]>;
 }

--- a/src/hexagon/application/queries/AdminReportQueries/usePrivateCallsByCoachReportQuery.ts
+++ b/src/hexagon/application/queries/AdminReportQueries/usePrivateCallsByCoachReportQuery.ts
@@ -1,0 +1,27 @@
+import type { PrivateCallsByCoach } from '@learncraft-spanish/shared';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useAdminReportsAdapter } from '@application/adapters/AdminReports/adminReportsAdapter';
+import { useAuthAdapter } from '@application/adapters/authAdapter';
+import { useQuery } from '@tanstack/react-query';
+
+export const PRIVATE_CALLS_BY_COACH_REPORT_QUERY_KEY = [
+  'privateCallsByCoachReport',
+] as const;
+
+export interface UsePrivateCallsByCoachReportQueryReturn {
+  privateCallsByCoachReportQuery: UseQueryResult<PrivateCallsByCoach[]>;
+}
+
+export function usePrivateCallsByCoachReportQuery(): UsePrivateCallsByCoachReportQueryReturn {
+  const adapter = useAdminReportsAdapter();
+  const { isAdmin } = useAuthAdapter();
+
+  const privateCallsByCoachReportQuery = useQuery({
+    queryKey: PRIVATE_CALLS_BY_COACH_REPORT_QUERY_KEY,
+    queryFn: () => adapter.getPrivateCallsByCoachReport(),
+    staleTime: Infinity,
+    enabled: isAdmin,
+  });
+
+  return { privateCallsByCoachReportQuery };
+}

--- a/src/hexagon/infrastructure/AdminReports/adminReportsInfrastructure.ts
+++ b/src/hexagon/infrastructure/AdminReports/adminReportsInfrastructure.ts
@@ -5,6 +5,7 @@ import type {
   CoachSummary,
   CoachSummaryDrilldown,
   MembershipsByCoach,
+  PrivateCallsByCoach,
 } from '@learncraft-spanish/shared';
 import { createHttpClient } from '@infrastructure/http/client';
 import {
@@ -14,6 +15,7 @@ import {
   getMembershipsByCoachTwoWeeksOutReportEndpoint,
   getMembershipsBySalariedCoachCurrentReportEndpoint,
   getMembershipsBySalariedCoachTwoWeeksOutReportEndpoint,
+  getPrivateCallsByCoachReportEndpoint,
   getWeeklyCoachSummaryReportEndpoint,
   getWeeksDrilldownReportEndpoint,
 } from '@learncraft-spanish/shared';
@@ -74,6 +76,11 @@ export function createAdminReportsInfrastructure(
         {
           params: { coachName, report },
         },
+      ),
+    getPrivateCallsByCoachReport: () =>
+      httpClient.get<PrivateCallsByCoach[]>(
+        getPrivateCallsByCoachReportEndpoint.path,
+        getPrivateCallsByCoachReportEndpoint.requiredScopes,
       ),
   };
 }

--- a/src/hooks/AdminData/usePrivateCallsByCoach.ts
+++ b/src/hooks/AdminData/usePrivateCallsByCoach.ts
@@ -1,21 +1,8 @@
-import type { PrivateCallData } from 'src/components/AdminDashboard/CallsByCoach/PrivateCallsByCoach/types';
-import { useQuery } from '@tanstack/react-query';
-import { deprecatedAdminReportQueryOptions } from './deprecatedAdminReportQueryOptions';
-// import { useBackendHelpers } from '../useBackend';
+import { usePrivateCallsByCoachReportQuery } from '@application/queries/AdminReportQueries/usePrivateCallsByCoachReportQuery';
+
 export default function usePrivateCallsByCoach() {
-  // const { getFactory } = useBackendHelpers();
+  const { privateCallsByCoachReportQuery } =
+    usePrivateCallsByCoachReportQuery();
 
-  const getPrivateCallsByCoach = (): Promise<PrivateCallData[]> => {
-    throw new Error('This feature is not available at this time.');
-    // return getFactory<PrivateCallData[]>('admin/report/private-calls-by-coach');
-  };
-
-  const privateCallsByCoachQuery = useQuery({
-    queryKey: ['private-calls-by-coach'],
-    queryFn: getPrivateCallsByCoach,
-    // staleTime: Infinity,
-    ...deprecatedAdminReportQueryOptions,
-  });
-
-  return { privateCallsByCoachQuery };
+  return { privateCallsByCoachQuery: privateCallsByCoachReportQuery };
 }

--- a/src/sections/AdminDashboard/useAdminDashboard.ts
+++ b/src/sections/AdminDashboard/useAdminDashboard.ts
@@ -1,15 +1,21 @@
 import useLastWeekCoachSummary from 'src/hooks/AdminData/useLastWeekCoachSummary';
+import usePrivateCallsByCoach from 'src/hooks/AdminData/usePrivateCallsByCoach';
 import useWeeklyCoachSummary from 'src/hooks/AdminData/useWeeklyCoachSummary';
 
 export default function useAdminDashboard() {
   const { weeklyCoachSummaryQuery } = useWeeklyCoachSummary();
   const { lastWeekCoachSummaryQuery } = useLastWeekCoachSummary();
+  const { privateCallsByCoachQuery } = usePrivateCallsByCoach();
 
   const isLoading =
-    weeklyCoachSummaryQuery.isLoading || lastWeekCoachSummaryQuery.isLoading;
+    weeklyCoachSummaryQuery.isLoading ||
+    lastWeekCoachSummaryQuery.isLoading ||
+    privateCallsByCoachQuery.isLoading;
 
   const isError =
-    weeklyCoachSummaryQuery.isError || lastWeekCoachSummaryQuery.isError;
+    weeklyCoachSummaryQuery.isError ||
+    lastWeekCoachSummaryQuery.isError ||
+    privateCallsByCoachQuery.isError;
 
   const isSuccess =
     weeklyCoachSummaryQuery.isSuccess && lastWeekCoachSummaryQuery.isSuccess;


### PR DESCRIPTION
## Summary
- Migrates the Private Calls by Coach admin report onto hexagon `AdminReports` ports/adapters/query hooks
- Updates the Calls by Coach UI to consume the new hexagon data path
- Bumps `@learncraft-spanish/shared` to `0.21.0`

## Test plan
- [ ] Open Admin Dashboard → Private Calls by Coach report loads
- [ ] Verify coach rows/totals match prior report behavior
- [ ] Confirm loading/error states behave correctly
- [ ] `pnpm test:hexagon:ai` / smoke the admin dashboard locally


Made with [Cursor](https://cursor.com)