### PR TITLE
feat: migrate Group Calls by Coach report to hexagon

### DIFF
--- a/src/components/AdminDashboard/CallsByCoach/CallsByCoach.tsx
+++ b/src/components/AdminDashboard/CallsByCoach/CallsByCoach.tsx
@@ -1,27 +1,41 @@
-import { useState } from 'react';
-import DeprecatedSectionHeader from '../DeprecatedSectionHeader';
-import PrivateCallsByCoach from './PrivateCallsByCoach';
-
-/* Deprecated — re-enable when group calls and calls drilldown are migrated.
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import GroupCallsByCoach from './GroupCallsByCoach';
 import GroupCallsDrilldownTable from './GroupCallsDrilldownTable';
-import PrivateCallsDrilldownTable from './PrivateCallsDrilldownTable';
-*/
+import PrivateCallsByCoach from './PrivateCallsByCoach';
 
 export default function CallsByCoach() {
   const [privateCallsByCoachOpen, setPrivateCallsByCoachOpen] = useState(false);
 
+  const [selectedReport, setSelectedReport] = useState<string | null>(null);
+  const [groupCallsByCoachOpen, setGroupCallsByCoachOpen] = useState(false);
+
+  const updateSelectedReport = (str: string) => {
+    setSelectedReport(str);
+  };
+
+  useEffect(() => {
+    if (!groupCallsByCoachOpen) {
+      setSelectedReport(null);
+    }
+  }, [groupCallsByCoachOpen]);
+
   return (
     <div className="section-with-interactive-table">
       <div className="admin-dashboard-grid">
-        <DeprecatedSectionHeader title="Group Calls by Coach" />
         <PrivateCallsByCoach
           setSelectedReport={() => undefined}
           isOpen={privateCallsByCoachOpen}
           setIsOpen={setPrivateCallsByCoachOpen}
         />
+        <GroupCallsByCoach
+          setSelectedReport={updateSelectedReport}
+          isOpen={groupCallsByCoachOpen}
+          setIsOpen={setGroupCallsByCoachOpen}
+        />
       </div>
+      {selectedReport?.includes('Group') && (
+        <GroupCallsDrilldownTable selectedReport={selectedReport} />
+      )}
     </div>
   );
 }

--- a/src/components/AdminDashboard/CallsByCoach/GroupCallsByCoach/GroupCallsByCoach.tsx
+++ b/src/components/AdminDashboard/CallsByCoach/GroupCallsByCoach/GroupCallsByCoach.tsx
@@ -1,4 +1,4 @@
-import type { GroupCallData } from './types';
+import type { GroupCallsByCoach as GroupCallData } from '@learncraft-spanish/shared';
 import DisplayOnlyTable from 'src/components/CoachingDashboard/components/RecentRecords/DisplayOnlyTable';
 import SectionHeader from 'src/components/CoachingDashboard/components/SectionHeader';
 import useGroupCallsByCoach from 'src/hooks/AdminData/useGroupCallsByCoach';

--- a/src/components/AdminDashboard/CallsByCoach/GroupCallsByCoach/types.ts
+++ b/src/components/AdminDashboard/CallsByCoach/GroupCallsByCoach/types.ts
@@ -1,1 +1,0 @@
-export type { GroupCallsByCoach as GroupCallData } from '@learncraft-spanish/shared';

--- a/src/components/AdminDashboard/CallsByCoach/GroupCallsByCoach/types.ts
+++ b/src/components/AdminDashboard/CallsByCoach/GroupCallsByCoach/types.ts
@@ -1,6 +1,1 @@
-interface GroupCallData {
-  coach: string;
-  numberOfGroupSessions: number;
-}
-
-export type { GroupCallData };
+export type { GroupCallsByCoach as GroupCallData } from '@learncraft-spanish/shared';

--- a/src/components/AdminDashboard/CallsByCoach/PrivateCallsByCoach/PrivateCallsByCoach.tsx
+++ b/src/components/AdminDashboard/CallsByCoach/PrivateCallsByCoach/PrivateCallsByCoach.tsx
@@ -1,4 +1,4 @@
-import type { PrivateCallData } from './types';
+import type { PrivateCallsByCoach as PrivateCallData } from '@learncraft-spanish/shared';
 import DisplayOnlyTable from 'src/components/CoachingDashboard/components/RecentRecords/DisplayOnlyTable';
 import SectionHeader from 'src/components/CoachingDashboard/components/SectionHeader';
 import usePrivateCallsByCoach from 'src/hooks/AdminData/usePrivateCallsByCoach';

--- a/src/components/AdminDashboard/CallsByCoach/PrivateCallsByCoach/types.ts
+++ b/src/components/AdminDashboard/CallsByCoach/PrivateCallsByCoach/types.ts
@@ -1,3 +1,0 @@
-import type { PrivateCallsByCoach } from '@learncraft-spanish/shared';
-
-export type { PrivateCallsByCoach as PrivateCallData };

--- a/src/hexagon/application/adapters/AdminReports/adminReportsAdapter.mock.ts
+++ b/src/hexagon/application/adapters/AdminReports/adminReportsAdapter.mock.ts
@@ -11,6 +11,7 @@ const defaultMockAdminReportsAdapter: AdminReportsPort = {
   getLastWeekCoachSummaryReport: async () => [],
   getWeeksDrilldownReport: async () => [],
   getPrivateCallsByCoachReport: async () => [],
+  getGroupCallsByCoachReport: async () => [],
 };
 
 export const {

--- a/src/hexagon/application/ports/AdminReports/adminReportsPort.ts
+++ b/src/hexagon/application/ports/AdminReports/adminReportsPort.ts
@@ -2,6 +2,7 @@ import type {
   AssignmentsCompletedByWeek,
   CoachSummary,
   CoachSummaryDrilldown,
+  GroupCallsByCoach,
   MembershipsByCoach,
   PrivateCallsByCoach,
 } from '@learncraft-spanish/shared';
@@ -28,4 +29,5 @@ export interface AdminReportsPort {
     report: WeeksDrilldownReportName,
   ) => Promise<CoachSummaryDrilldown[]>;
   getPrivateCallsByCoachReport: () => Promise<PrivateCallsByCoach[]>;
+  getGroupCallsByCoachReport: () => Promise<GroupCallsByCoach[]>;
 }

--- a/src/hexagon/application/queries/AdminReportQueries/useGroupCallsByCoachReportQuery.mock.ts
+++ b/src/hexagon/application/queries/AdminReportQueries/useGroupCallsByCoachReportQuery.mock.ts
@@ -1,0 +1,24 @@
+import type { GroupCallsByCoach } from '@learncraft-spanish/shared';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { createMockGroupCallsByCoachList } from '@testing/factories/adminReportsFactory';
+import { createOverrideableMock } from '@testing/utils/createOverrideableMock';
+
+const defaultMockData: GroupCallsByCoach[] = createMockGroupCallsByCoachList(2);
+
+const defaultMockReturn = {
+  groupCallsByCoachReportQuery: {
+    data: defaultMockData,
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    status: 'success',
+  } as UseQueryResult<GroupCallsByCoach[]>,
+};
+
+export const {
+  mock: mockUseGroupCallsByCoachReportQuery,
+  override: overrideMockUseGroupCallsByCoachReportQuery,
+  reset: resetMockUseGroupCallsByCoachReportQuery,
+} = createOverrideableMock(defaultMockReturn);
+
+export default mockUseGroupCallsByCoachReportQuery;

--- a/src/hexagon/application/queries/AdminReportQueries/useGroupCallsByCoachReportQuery.test.ts
+++ b/src/hexagon/application/queries/AdminReportQueries/useGroupCallsByCoachReportQuery.test.ts
@@ -1,0 +1,75 @@
+import { overrideMockAdminReportsAdapter } from '@application/adapters/AdminReports/adminReportsAdapter.mock';
+import { overrideMockAuthAdapter } from '@application/adapters/authAdapter.mock';
+import { useGroupCallsByCoachReportQuery } from '@application/queries/AdminReportQueries/useGroupCallsByCoachReportQuery';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createMockGroupCallsByCoachList } from '@testing/factories/adminReportsFactory';
+import { TestQueryClientProvider } from '@testing/providers/TestQueryClientProvider';
+import { describe, expect, it } from 'vitest';
+
+describe('useGroupCallsByCoachReportQuery', () => {
+  it('should fetch group calls by coach report', async () => {
+    const mockData = createMockGroupCallsByCoachList(2);
+    overrideMockAdminReportsAdapter({
+      getGroupCallsByCoachReport: async () => mockData,
+    });
+
+    const { result } = renderHook(() => useGroupCallsByCoachReportQuery(), {
+      wrapper: TestQueryClientProvider,
+    });
+
+    expect(result.current.groupCallsByCoachReportQuery.isLoading).toBe(true);
+
+    await waitFor(() =>
+      expect(result.current.groupCallsByCoachReportQuery.isLoading).toBe(false),
+    );
+    expect(result.current.groupCallsByCoachReportQuery.isSuccess).toBe(true);
+    expect(result.current.groupCallsByCoachReportQuery.data).toEqual(mockData);
+  });
+
+  it('should return empty array when there are no group calls', async () => {
+    overrideMockAdminReportsAdapter({
+      getGroupCallsByCoachReport: async () => [],
+    });
+
+    const { result } = renderHook(() => useGroupCallsByCoachReportQuery(), {
+      wrapper: TestQueryClientProvider,
+    });
+
+    await waitFor(() =>
+      expect(result.current.groupCallsByCoachReportQuery.isLoading).toBe(false),
+    );
+    expect(result.current.groupCallsByCoachReportQuery.data).toEqual([]);
+  });
+
+  it('should expose error state when the fetch fails', async () => {
+    overrideMockAdminReportsAdapter({
+      getGroupCallsByCoachReport: async () => {
+        throw new Error('Failed to fetch group calls by coach report');
+      },
+    });
+
+    const { result } = renderHook(() => useGroupCallsByCoachReportQuery(), {
+      wrapper: TestQueryClientProvider,
+    });
+
+    await waitFor(() =>
+      expect(result.current.groupCallsByCoachReportQuery.isLoading).toBe(false),
+    );
+    expect(result.current.groupCallsByCoachReportQuery.isError).toBe(true);
+    expect(result.current.groupCallsByCoachReportQuery.data).toBeUndefined();
+  });
+
+  it('should not fetch when user is not admin', async () => {
+    overrideMockAuthAdapter({ isAdmin: false });
+
+    const { result } = renderHook(() => useGroupCallsByCoachReportQuery(), {
+      wrapper: TestQueryClientProvider,
+    });
+
+    await waitFor(() =>
+      expect(result.current.groupCallsByCoachReportQuery.isLoading).toBe(false),
+    );
+    expect(result.current.groupCallsByCoachReportQuery.status).toBe('pending');
+    expect(result.current.groupCallsByCoachReportQuery.data).toBeUndefined();
+  });
+});

--- a/src/hexagon/application/queries/AdminReportQueries/useGroupCallsByCoachReportQuery.ts
+++ b/src/hexagon/application/queries/AdminReportQueries/useGroupCallsByCoachReportQuery.ts
@@ -1,0 +1,27 @@
+import type { GroupCallsByCoach } from '@learncraft-spanish/shared';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useAdminReportsAdapter } from '@application/adapters/AdminReports/adminReportsAdapter';
+import { useAuthAdapter } from '@application/adapters/authAdapter';
+import { useQuery } from '@tanstack/react-query';
+
+export const GROUP_CALLS_BY_COACH_REPORT_QUERY_KEY = [
+  'groupCallsByCoachReport',
+] as const;
+
+export interface UseGroupCallsByCoachReportQueryReturn {
+  groupCallsByCoachReportQuery: UseQueryResult<GroupCallsByCoach[]>;
+}
+
+export function useGroupCallsByCoachReportQuery(): UseGroupCallsByCoachReportQueryReturn {
+  const adapter = useAdminReportsAdapter();
+  const { isAdmin } = useAuthAdapter();
+
+  const groupCallsByCoachReportQuery = useQuery({
+    queryKey: GROUP_CALLS_BY_COACH_REPORT_QUERY_KEY,
+    queryFn: () => adapter.getGroupCallsByCoachReport(),
+    staleTime: Infinity,
+    enabled: isAdmin,
+  });
+
+  return { groupCallsByCoachReportQuery };
+}

--- a/src/hexagon/infrastructure/AdminReports/adminReportsInfrastructure.ts
+++ b/src/hexagon/infrastructure/AdminReports/adminReportsInfrastructure.ts
@@ -4,12 +4,14 @@ import type {
   AssignmentsCompletedByWeek,
   CoachSummary,
   CoachSummaryDrilldown,
+  GroupCallsByCoach,
   MembershipsByCoach,
   PrivateCallsByCoach,
 } from '@learncraft-spanish/shared';
 import { createHttpClient } from '@infrastructure/http/client';
 import {
   getAssignmentsCompletedByWeekReportEndpoint,
+  getGroupCallsByCoachReportEndpoint,
   getLastWeekCoachSummaryReportEndpoint,
   getMembershipsByCoachCurrentReportEndpoint,
   getMembershipsByCoachTwoWeeksOutReportEndpoint,
@@ -81,6 +83,11 @@ export function createAdminReportsInfrastructure(
       httpClient.get<PrivateCallsByCoach[]>(
         getPrivateCallsByCoachReportEndpoint.path,
         getPrivateCallsByCoachReportEndpoint.requiredScopes,
+      ),
+    getGroupCallsByCoachReport: () =>
+      httpClient.get<GroupCallsByCoach[]>(
+        getGroupCallsByCoachReportEndpoint.path,
+        getGroupCallsByCoachReportEndpoint.requiredScopes,
       ),
   };
 }

--- a/src/hexagon/testing/factories/adminReportsFactory.ts
+++ b/src/hexagon/testing/factories/adminReportsFactory.ts
@@ -3,6 +3,7 @@ import {
   assignmentsCompletedByWeekSchema,
   coachSummaryDrilldownSchema,
   coachSummarySchema,
+  groupCallsByCoachSchema,
   membershipsByCoachSchema,
 } from '@learncraft-spanish/shared';
 import {
@@ -40,4 +41,11 @@ export const createMockCoachSummaryDrilldown = createZodFactory(
 );
 export const createMockCoachSummaryDrilldownList = createZodListFactory(
   coachSummaryDrilldownSchema,
+);
+
+export const createMockGroupCallsByCoach = createZodFactory(
+  groupCallsByCoachSchema,
+);
+export const createMockGroupCallsByCoachList = createZodListFactory(
+  groupCallsByCoachSchema,
 );

--- a/src/hooks/AdminData/useGroupCallsByCoach.ts
+++ b/src/hooks/AdminData/useGroupCallsByCoach.ts
@@ -1,21 +1,6 @@
-import type { GroupCallData } from 'src/components/AdminDashboard/CallsByCoach/GroupCallsByCoach/types';
-import { useQuery } from '@tanstack/react-query';
-import { deprecatedAdminReportQueryOptions } from './deprecatedAdminReportQueryOptions';
-// import { useBackendHelpers } from '../useBackend';
+import { useGroupCallsByCoachReportQuery } from '@application/queries/AdminReportQueries/useGroupCallsByCoachReportQuery';
+
 export default function useGroupCallsByCoach() {
-  // const { getFactory } = useBackendHelpers();
-
-  const getGroupCallsByCoach = (): Promise<GroupCallData[]> => {
-    throw new Error('This feature is not available at this time.');
-    // return getFactory<GroupCallData[]>('admin/report/group-calls-by-coach');
-  };
-
-  const groupCallsByCoachQuery = useQuery({
-    queryKey: ['group-calls-by-coach'],
-    queryFn: getGroupCallsByCoach,
-    // staleTime: Infinity,
-    ...deprecatedAdminReportQueryOptions,
-  });
-
-  return { groupCallsByCoachQuery };
+  const { groupCallsByCoachReportQuery } = useGroupCallsByCoachReportQuery();
+  return { groupCallsByCoachQuery: groupCallsByCoachReportQuery };
 }

--- a/src/hooks/AdminData/useReportCallsDrilldown.ts
+++ b/src/hooks/AdminData/useReportCallsDrilldown.ts
@@ -1,5 +1,7 @@
-import type { GroupCallData } from 'src/components/AdminDashboard/CallsByCoach/GroupCallsByCoach/types';
-import type { PrivateCallData } from 'src/components/AdminDashboard/CallsByCoach/PrivateCallsByCoach/types';
+import type {
+  GroupCallsByCoach,
+  PrivateCallsByCoach,
+} from '@learncraft-spanish/shared';
 import { useQuery } from '@tanstack/react-query';
 import { deprecatedAdminReportQueryOptions } from './deprecatedAdminReportQueryOptions';
 // import { useBackendHelpers } from '../useBackend';
@@ -13,11 +15,11 @@ export default function useReportCallsDrilldown(
   const getReportCallsDrilldown = async (
     _coachId: string,
     _report: string,
-  ): Promise<GroupCallData[] | PrivateCallData[]> => {
+  ): Promise<GroupCallsByCoach[] | PrivateCallsByCoach[]> => {
     throw new Error('This feature is not available at this time.');
     // const formattedCoachId = _coachId.replace(' ', '+');
     // const formattedReportName = _report.replace(' ', '+');
-    // return getFactory<GroupCallData[] | PrivateCallData[]>(`admin/calls-report-drilldown?coachId=${formattedCoachId}&report=${formattedReportName}`);
+    // return getFactory<GroupCallsByCoach[] | PrivateCallsByCoach[]>(`admin/calls-report-drilldown?coachId=${formattedCoachId}&report=${formattedReportName}`);
   };
 
   const reportCallsDrilldownQuery = useQuery({

--- a/src/sections/AdminDashboard/useAdminDashboard.ts
+++ b/src/sections/AdminDashboard/useAdminDashboard.ts
@@ -1,3 +1,4 @@
+import useGroupCallsByCoach from 'src/hooks/AdminData/useGroupCallsByCoach';
 import useLastWeekCoachSummary from 'src/hooks/AdminData/useLastWeekCoachSummary';
 import usePrivateCallsByCoach from 'src/hooks/AdminData/usePrivateCallsByCoach';
 import useWeeklyCoachSummary from 'src/hooks/AdminData/useWeeklyCoachSummary';
@@ -6,21 +7,25 @@ export default function useAdminDashboard() {
   const { weeklyCoachSummaryQuery } = useWeeklyCoachSummary();
   const { lastWeekCoachSummaryQuery } = useLastWeekCoachSummary();
   const { privateCallsByCoachQuery } = usePrivateCallsByCoach();
+  const { groupCallsByCoachQuery } = useGroupCallsByCoach();
 
   const isLoading =
     weeklyCoachSummaryQuery.isLoading ||
     lastWeekCoachSummaryQuery.isLoading ||
-    privateCallsByCoachQuery.isLoading;
+    privateCallsByCoachQuery.isLoading ||
+    groupCallsByCoachQuery.isLoading;
 
   const isError =
     weeklyCoachSummaryQuery.isError ||
     lastWeekCoachSummaryQuery.isError ||
-    privateCallsByCoachQuery.isError;
+    privateCallsByCoachQuery.isError ||
+    groupCallsByCoachQuery.isError;
 
   const isSuccess =
     weeklyCoachSummaryQuery.isSuccess &&
     lastWeekCoachSummaryQuery.isSuccess &&
-    privateCallsByCoachQuery.isSuccess;
+    privateCallsByCoachQuery.isSuccess &&
+    groupCallsByCoachQuery.isSuccess;
 
   return {
     isLoading,


### PR DESCRIPTION
## Summary
- Migrates the Group Calls by Coach admin report onto hexagon `AdminReports` ports/adapters/query hooks
- Updates the Calls by Coach UI to consume the new hexagon data path
- Bumps `@learncraft-spanish/shared` to `0.21.0`

## Test plan
- [ ] Open Admin Dashboard → Group Calls by Coach report loads
- [ ] Verify coach rows/totals match prior report behavior
- [ ] Confirm loading/error states behave correctly
- [ ] `pnpm test:hexagon:ai` / smoke the admin dashboard locally


Made with [Cursor](https://cursor.com)